### PR TITLE
Fix editor query selection

### DIFF
--- a/scripts/onLoad.js
+++ b/scripts/onLoad.js
@@ -14,5 +14,5 @@ $(document).ready(() => {
 
 
 function attachTribute(){
-  tribute.attach(document.querySelector(".editor")[0]);
+  tribute.attach(document.querySelector(".editor"));
 }


### PR DESCRIPTION
## Summary
- fix tribute attach logic to use `querySelector` directly

## Testing
- `node -v` *(fails: command not found)*