### PR TITLE
Fix missing MAX_BACKOFF import

### DIFF
--- a/src/events/notificationEvents.js
+++ b/src/events/notificationEvents.js
@@ -9,6 +9,7 @@ import {
   WS_ENDPOINT,
   ANN_ID,
   KEEPALIVE_MS,
+  MAX_BACKOFF,
   renderedNotificationIds
 } from '../config.js';
 


### PR DESCRIPTION
## Summary
- import `MAX_BACKOFF` in notificationEvents

## Testing
- `git status --short`