### PR TITLE
Fix missing formatter imports

### DIFF
--- a/src/events/notificationEvents.js
+++ b/src/events/notificationEvents.js
@@ -12,6 +12,7 @@ import {
   MAX_BACKOFF,
   renderedNotificationIds
 } from '../config.js';
+import { parseDate, timeAgo } from '../utils/formatter.js';
 
 export function initNotifications() {
   const bell = document.querySelector(".notificationWrapperToggler");

--- a/src/ui/render.js
+++ b/src/ui/render.js
@@ -1,3 +1,6 @@
+import { safeArray, timeAgo, parseDate } from '../utils/formatter.js';
+import { GLOBAL_AUTHOR_ID, DEFAULT_AVATAR } from '../config.js';
+
 export function mergeWithExisting(existingPosts, newRawPosts, depth = 0) {
   return newRawPosts.map(newRaw => {
     // Find existing post by ID to preserve its state


### PR DESCRIPTION
## Summary
- import `safeArray`, `timeAgo`, and `parseDate` into `render.js`
- import formatter helpers into `notificationEvents.js`

The new imports resolve `ReferenceError: safeArray is not defined` that occurred when rendering posts.

## Testing
- `git status --short`