### PR TITLE
Fix comment reply file upload

### DIFF
--- a/src/events/forumEvents.js
+++ b/src/events/forumEvents.js
@@ -26,6 +26,7 @@ import {
   setFileTypeCheck,
 } from './uploadHandlers.js';
 import { tribute } from '../utils/tribute.js';
+import { initFilePond } from '../utils/filePond.js';
 import { processFileFields } from '../utils/handleFile.js';
 
 $(document).on("click", ".btn-comment", function (e) {


### PR DESCRIPTION
## Summary
- fix ReferenceError by importing `initFilePond` in `forumEvents.js`

## Testing
- `node -e "import('./src/events/forumEvents.js').then(()=>console.log('OK')).catch(err=>console.error(err))" && echo done` *(fails: window is not defined)*