### PR TITLE
Remove console log from applyFilterAndRender

### DIFF
--- a/src/events/forumEvents.js
+++ b/src/events/forumEvents.js
@@ -331,8 +331,6 @@ $(document).on("click", ".btn-bookmark", async function () {
 });
 
 export function applyFilterAndRender() {
-  console.log("Function is running");
-
   requestAnimationFrame(() => {
     Plyr.setup(".js-player");
   });


### PR DESCRIPTION
## Summary
- remove extraneous debug log from `applyFilterAndRender`
- clean up blank line

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_b_683fd653708c8321b1c4077b42e1fd44