### PR TITLE
Persist collapsed state

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -42,6 +42,7 @@ export const state = {
   rawPosts: [],
   rawComments: [],
   postsStore: [],
+  collapsedState: {},
   currentFilter: "Recent",
   currentFileFilter: "All",
   currentSearchTerm: "",

--- a/src/events/forumEvents.js
+++ b/src/events/forumEvents.js
@@ -81,6 +81,7 @@ $(document).on("click", ".ribbon", function () {
   let node = findNode(state.postsStore, uid);
   if (node) {
     node.isCollapsed = !node.isCollapsed;
+    state.collapsedState[node.uid] = node.isCollapsed;
     applyFilterAndRender();
   }
 });
@@ -238,6 +239,7 @@ $(document).on("click", ".btn-submit-comment", async function () {
     setFileTypeCheck("");
     $form.remove();
     node.isCollapsed = false;
+    state.collapsedState[node.uid] = node.isCollapsed;
     $(`[data-uid="${uid}"]`).find(".children").addClass("visible");
   } catch (err) {
     console.error("Comment failed", err);

--- a/src/ui/render.js
+++ b/src/ui/render.js
@@ -1,17 +1,21 @@
 import { safeArray, timeAgo, parseDate } from '../utils/formatter.js';
-import { GLOBAL_AUTHOR_ID, DEFAULT_AVATAR } from '../config.js';
+import { GLOBAL_AUTHOR_ID, DEFAULT_AVATAR, state } from '../config.js';
 
 export function buildTree(existingPosts, rawPosts, rawComments) {
   const byUid = new Map();
 
   function cloneState(uid) {
-    const existing = findNode(existingPosts, uid);
-    return existing ? { isCollapsed: existing.isCollapsed } : { isCollapsed: true };
+    if (state.collapsedState.hasOwnProperty(uid)) {
+      return { isCollapsed: state.collapsedState[uid] };
+    }
+    state.collapsedState[uid] = true;
+    return { isCollapsed: true };
   }
 
   const posts = rawPosts.map(raw => {
     const node = mapItem(raw, 0);
     Object.assign(node, cloneState(node.uid));
+    state.collapsedState[node.uid] = node.isCollapsed;
     byUid.set(node.id, node);
     return node;
   });
@@ -19,6 +23,7 @@ export function buildTree(existingPosts, rawPosts, rawComments) {
   const comments = rawComments.map(raw => {
     const node = mapItem(raw, 1);
     Object.assign(node, cloneState(node.uid));
+    state.collapsedState[node.uid] = node.isCollapsed;
     byUid.set(node.id, node);
     return node;
   });


### PR DESCRIPTION
## Summary
- track expanded/collapsed comments in `state.collapsedState`
- have `buildTree` read/write the map when generating nodes
- update actions that toggle collapse to sync the map

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_683fd653d8ac8321900a9448f03456f3