### PR TITLE
Implement visibility based socket handling

### DIFF
--- a/src/events/notificationEvents.js
+++ b/src/events/notificationEvents.js
@@ -132,6 +132,24 @@ export function initNotifications() {
   }
 
   connectNotifications();
+
+  document.addEventListener("visibilitychange", () => {
+    if (document.hidden) {
+      clearInterval(keepAliveTimer);
+      if (socket && socket.readyState === WebSocket.OPEN) {
+        socket.close();
+      }
+    } else {
+      if (!socket || socket.readyState === WebSocket.CLOSED) {
+        connectNotifications();
+      } else {
+        keepAliveTimer = setInterval(
+          () => sendSafe({ type: "KEEP_ALIVE" }),
+          KEEPALIVE_MS
+        );
+      }
+    }
+  });
 }
 
 document.getElementById("markAllAsRead").addEventListener("click", async () => {

--- a/src/main.js
+++ b/src/main.js
@@ -73,6 +73,25 @@ export function connect() {
   });
 }
 
+document.addEventListener("visibilitychange", () => {
+  if (document.hidden) {
+    clearInterval(state.keepAliveTimer);
+    if (state.socket && state.socket.readyState === WebSocket.OPEN) {
+      state.socket.close();
+    }
+  } else {
+    if (!state.socket || state.socket.readyState === WebSocket.CLOSED) {
+      connect();
+    } else {
+      state.keepAliveTimer = setInterval(() => {
+        if (state.socket.readyState === WebSocket.OPEN) {
+          state.socket.send(JSON.stringify({ type: "KEEP_ALIVE" }));
+        }
+      }, KEEPALIVE_MS);
+    }
+  }
+});
+
 window.addEventListener('DOMContentLoaded', () => {
   tribute.attach(document.getElementById('post-editor'));
   fetchGraphQL(FETCH_CONTACTS_QUERY).then((res) => {


### PR DESCRIPTION
## Summary
- close sockets and clear keep-alive intervals when the page goes hidden
- reconnect WebSockets and restart timers when the page becomes visible again

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_683fd65323dc832183142008ac9686ca