### PR TITLE
Fix audio clearing bug

### DIFF
--- a/src/utils/filePond.js
+++ b/src/utils/filePond.js
@@ -80,6 +80,13 @@ export function initFilePond() {
       container.appendChild(mediaEl);
     });
 
+    pond.on("removefile", () => {
+      setPendingFile(null);
+      setFileTypeCheck("");
+      inputElement.value = "";
+      canvas.style.display = "none";
+    });
+
     const recorder = new MicRecorder({ bitRate: 128 });
     let isRecording = false;
     let audioContext, analyser, dataArray, source, animationId, mediaStream;


### PR DESCRIPTION
## Summary
- clear pending audio when FilePond file is removed

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_683fffbaa8b48321bc291792b6d5b14f