### PR TITLE
Add modal preview for post attachments

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -190,6 +190,12 @@
 
   <script type="module" src="../src/main.js"></script>
 
+<div id="file-preview-modal" class="hidden fixed inset-0 bg-black/75 flex items-center justify-center z-[99]">
+  <div class="modal-content bg-white p-4 rounded relative max-w-full max-h-full">
+    <button id="close-file-preview" class="absolute top-2 right-2">✕</button>
+    <div id="preview-container" class="max-h-[80vh] overflow-auto"></div>
+  </div>
+</div>
 </body>
 
 </html>

--- a/public/styles/style.css
+++ b/public/styles/style.css
@@ -220,3 +220,17 @@ button {
   padding: 0 0.25rem;
   border-radius: 0.25rem;
 }
+/* file preview modal */
+#file-preview-modal {
+  display: none;
+}
+#file-preview-modal.show {
+  display: flex;
+}
+#file-preview-modal img,
+#file-preview-modal video,
+#file-preview-modal audio,
+#file-preview-modal iframe {
+  max-width: 100%;
+  max-height: 80vh;
+}

--- a/src/features/posts/events.js
+++ b/src/features/posts/events.js
@@ -470,3 +470,56 @@ function removeHighlights(el) {
 }
 
 
+
+// File preview modal logic
+const previewModal = document.getElementById('file-preview-modal');
+const previewContainer = document.getElementById('preview-container');
+const previewClose = document.getElementById('close-file-preview');
+
+if (previewClose) {
+  previewClose.addEventListener('click', () => {
+    previewModal.classList.add('hidden');
+    previewModal.classList.remove('show');
+    previewContainer.innerHTML = '';
+  });
+}
+
+if (previewModal) {
+  previewModal.addEventListener('click', (e) => {
+    if (e.target === previewModal) {
+      previewClose.click();
+    }
+  });
+}
+
+$(document).on(
+  'click',
+  '.file-preview img, .file-preview video, .file-preview audio, .file-preview a',
+  function (e) {
+    e.preventDefault();
+    if (!previewModal) return;
+    let src = this.src || $(this).attr('href');
+    if (!src) return;
+    let el;
+    if (this.tagName.toLowerCase() === 'img') {
+      el = document.createElement('img');
+      el.src = src;
+    } else if (this.tagName.toLowerCase() === 'video') {
+      el = document.createElement('video');
+      el.src = src;
+      el.controls = true;
+    } else if (this.tagName.toLowerCase() === 'audio') {
+      el = document.createElement('audio');
+      el.src = src;
+      el.controls = true;
+    } else {
+      el = document.createElement('iframe');
+      el.src = src;
+      el.className = 'w-full h-full';
+    }
+    previewContainer.innerHTML = '';
+    previewContainer.appendChild(el);
+    previewModal.classList.remove('hidden');
+    previewModal.classList.add('show');
+  }
+);


### PR DESCRIPTION
## Summary
- enable preview of attachments via modal overlay
- style modal and add container in index
- handle clicks on file previews to open modal

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_683fffef84f88321a0cccaa897dbc519