### PR TITLE
Implement delete confirmation modal

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -90,6 +90,17 @@
 
   <div id="forum-root" class="w-full"></div>
 
+  <!-- Delete confirmation modal -->
+  <div id="delete-modal" class="hidden fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+    <div class="bg-white p-4 rounded shadow-lg w-[90%] max-w-sm">
+      <h2 id="delete-modal-title" class="text-lg font-bold mb-4"></h2>
+      <div class="flex justify-end gap-2">
+        <button id="delete-confirm" class="bg-red-500 text-white px-4 py-1 rounded">Delete</button>
+        <button id="delete-cancel" class="bg-gray-300 px-4 py-1 rounded">Cancel</button>
+      </div>
+    </div>
+  </div>
+
   <script id="tmpl-item" type="text/x-jsrender">
     <div 
       class="item rounded bg-white shadow-xl flex flex-col gap-2 my-4 p-4 relative border-2 border-[#e9ebee]" 

--- a/src/features/posts/events.js
+++ b/src/features/posts/events.js
@@ -29,6 +29,10 @@ import { tribute } from '../../utils/tribute.js';
 import { initFilePond } from '../../utils/filePond.js';
 import { processFileFields } from '../../utils/handleFile.js';
 
+const deleteModal = document.getElementById('delete-modal');
+const deleteModalTitle = document.getElementById('delete-modal-title');
+let pendingDelete = null;
+
 $(document).on("click", ".btn-comment", function (e) {
   e.stopPropagation();
   const uid = $(this).data("uid");
@@ -88,7 +92,22 @@ $(document).on("click", ".ribbon", function () {
 
 $(document).on("click", ".btn-delete", function () {
   const uid = $(this).data("uid");
-  const $item = $(this).closest(".item");
+  pendingDelete = { uid };
+  const node = findNode(state.postsStore, uid);
+  const label = node.depth === 0 ? "post" : node.depth === 1 ? "comment" : "reply";
+  deleteModalTitle.textContent = `Do you want to delete this ${label}?`;
+  deleteModal.classList.remove("hidden");
+});
+
+$(document).on("click", "#delete-cancel", function () {
+  deleteModal.classList.add("hidden");
+  pendingDelete = null;
+});
+
+$(document).on("click", "#delete-confirm", function () {
+  if (!pendingDelete) return;
+  const uid = pendingDelete.uid;
+  const $item = $(`[data-uid="${uid}"]`).closest(".item");
   $item.addClass("state-disabled");
 
   let node;
@@ -117,6 +136,10 @@ $(document).on("click", ".btn-delete", function () {
     .catch((err) => {
       console.error("Delete failed", err);
       $item.removeClass("state-disabled");
+    })
+    .finally(() => {
+      deleteModal.classList.add("hidden");
+      pendingDelete = null;
     });
 });
 


### PR DESCRIPTION
## Summary
- add a delete confirmation modal to `index.html`
- hook up modal logic in `events.js`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_683fffe1eb648321a202a98ef004ff7c