### PR TITLE
Add empty state message for empty search

### DIFF
--- a/public/styles/style.css
+++ b/public/styles/style.css
@@ -220,3 +220,9 @@ button {
   padding: 0 0.25rem;
   border-radius: 0.25rem;
 }
+
+.empty-state {
+  color: #555;
+  text-align: center;
+  padding: 1rem;
+}

--- a/src/features/posts/events.js
+++ b/src/features/posts/events.js
@@ -374,7 +374,13 @@ export function applyFilterAndRender() {
         p.content.toLowerCase().includes(q)
     );
   }
-  $("#forum-root").html(tmpl.render(items));
+  if (items.length === 0) {
+    $("#forum-root").html(
+      '<div class="empty-state text-center p-4">No posts found.</div>'
+    );
+  } else {
+    $("#forum-root").html(tmpl.render(items));
+  }
 }
 
 $(document).on("click", ".filter-btn", function () {


### PR DESCRIPTION
## Summary
- show a simple empty state message when filters or search yield no posts
- style the new empty state message

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_683fffd8b8248321b636e7047a3e1d10