### PR TITLE
Add download control to Plyr players

### DIFF
--- a/src/features/posts/events.js
+++ b/src/features/posts/events.js
@@ -122,7 +122,32 @@ $(document).on("click", ".btn-delete", function () {
 
 $(document).on("click", "#submit-post", async function () {
   requestAnimationFrame(() => {
-    Plyr.setup(".js-player");
+    Plyr.setup('.js-player', {
+      controls: [
+        'play-large',
+        'restart',
+        'rewind',
+        'play',
+        'fast-forward',
+        'progress',
+        'current-time',
+        'duration',
+        'mute',
+        'volume',
+        'captions',
+        'settings',
+        'pip',
+        'airplay',
+        'download',
+        'fullscreen',
+      ],
+      settings: ['captions', 'quality', 'speed'],
+      tooltips: { controls: true, seek: true },
+      clickToPlay: true,
+      autoplay: false,
+      muted: false,
+      loop: { active: false },
+    });
   });
   const $btn = $(this);
   const formWrapper = document.querySelector(".post-form ");
@@ -349,7 +374,32 @@ $(document).on("click", ".btn-bookmark", async function () {
 
 export function applyFilterAndRender() {
   requestAnimationFrame(() => {
-    Plyr.setup(".js-player");
+    Plyr.setup('.js-player', {
+      controls: [
+        'play-large',
+        'restart',
+        'rewind',
+        'play',
+        'fast-forward',
+        'progress',
+        'current-time',
+        'duration',
+        'mute',
+        'volume',
+        'captions',
+        'settings',
+        'pip',
+        'airplay',
+        'download',
+        'fullscreen',
+      ],
+      settings: ['captions', 'quality', 'speed'],
+      tooltips: { controls: true, seek: true },
+      clickToPlay: true,
+      autoplay: false,
+      muted: false,
+      loop: { active: false },
+    });
   });
   let items = state.postsStore;
   switch (state.currentFilter) {

--- a/src/main.js
+++ b/src/main.js
@@ -60,7 +60,32 @@ export function connect() {
       state.postsStore = buildTree(state.postsStore, state.rawPosts, state.rawComments);
       applyFilterAndRender();
       requestAnimationFrame(() => {
-        Plyr.setup('.js-player');
+        Plyr.setup('.js-player', {
+          controls: [
+            'play-large',
+            'restart',
+            'rewind',
+            'play',
+            'fast-forward',
+            'progress',
+            'current-time',
+            'duration',
+            'mute',
+            'volume',
+            'captions',
+            'settings',
+            'pip',
+            'airplay',
+            'download',
+            'fullscreen',
+          ],
+          settings: ['captions', 'quality', 'speed'],
+          tooltips: { controls: true, seek: true },
+          clickToPlay: true,
+          autoplay: false,
+          muted: false,
+          loop: { active: false },
+        });
       });
     } else if (msg.type === "GQL_ERROR") {
       console.error("Subscription error", msg.payload);


### PR DESCRIPTION
## Summary
- expose download option in player setup
- configure the same options wherever Plyr is initialized

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_683fffd0e5d88321b95031aabaa9e913