### PR TITLE
Add download button to file preview modal

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -204,6 +204,7 @@
 <div id="file-preview-modal" class="hidden fixed inset-0 bg-black/75 flex items-center justify-center z-[99]">
   <div class="modal-content bg-white p-4 rounded relative max-w-full max-h-full">
     <button id="close-file-preview" class="absolute top-2 right-2">✕</button>
+    <a id="download-preview" href="#" download class="absolute top-2 left-2">⬇</a>
     <div id="preview-container" class="max-h-[80vh] overflow-auto"></div>
   </div>
 </div>

--- a/public/styles/style.css
+++ b/public/styles/style.css
@@ -247,3 +247,14 @@ button {
   max-width: 100%;
   max-height: 80vh;
 }
+
+#close-file-preview,
+#download-preview {
+  background: rgba(0, 0, 0, 0.6);
+  color: #fff;
+  border: none;
+  font-size: 1.5rem;
+  padding: 0.25rem 0.5rem;
+  cursor: pointer;
+  border-radius: 4px;
+}

--- a/src/features/posts/events.js
+++ b/src/features/posts/events.js
@@ -559,6 +559,7 @@ function removeHighlights(el) {
 const previewModal = document.getElementById('file-preview-modal');
 const previewContainer = document.getElementById('preview-container');
 const previewClose = document.getElementById('close-file-preview');
+const previewDownload = document.getElementById('download-preview');
 
 if (previewClose) {
   previewClose.addEventListener('click', () => {
@@ -603,6 +604,10 @@ $(document).on(
     }
     previewContainer.innerHTML = '';
     previewContainer.appendChild(el);
+    if (previewDownload) {
+      previewDownload.href = src;
+      previewDownload.download = src.split('/').pop();
+    }
     previewModal.classList.remove('hidden');
     previewModal.classList.add('show');
   }


### PR DESCRIPTION
## Summary
- add download icon to the file preview modal
- style the close and download buttons for visibility
- set download link dynamically in modal logic

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68400f2181ec83218aa96fa3fba3db7c