### PR TITLE
Add post sorting dropdown

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -90,6 +90,16 @@
           <li class="py-2 px-8 cursor-pointer" data-type="File">File</li>
         </ul>
       </div>
+
+      <div class="sort-filter relative ml-2">
+        <button id="sort-filter-btn" class="filter-btn">Latest ▾</button>
+        <ul id="sort-filter-menu"
+          class="sort-filter-menu absolute top-[100%] right-0 bg-[#ffffff] border border-1-[#ccc] list-style-none p-0 mr-[4px] min-w-[8em] z-[10]">
+          <li class="py-2 px-8 cursor-pointer active" data-sort="Latest">Latest</li>
+          <li class="py-2 px-8 cursor-pointer" data-sort="Oldest">Oldest</li>
+          <li class="py-2 px-8 cursor-pointer" data-sort="Most Popular">Most Popular</li>
+        </ul>
+      </div>
     </div>
     <div class="search-wrapper w-full my-4 relative">
       <input type="text" id="searchPost" class="py-2 px-4 rounded text-sm" placeholder="Search by author or text…"

--- a/public/styles/style.css
+++ b/public/styles/style.css
@@ -94,6 +94,20 @@ button {
   display: block;
 }
 
+.sort-filter-menu {
+  display: none;
+}
+
+.sort-filter-menu li:hover,
+.sort-filter-menu li.active {
+  background-color: #007bff;
+  color: #fff;
+}
+
+.sort-filter.open .sort-filter-menu {
+  display: block;
+}
+
 .clearIcon.hidden {
   display: none;
 }

--- a/src/config.js
+++ b/src/config.js
@@ -45,6 +45,7 @@ export const state = {
   collapsedState: {},
   currentFilter: "Recent",
   currentFileFilter: "All",
+  currentSort: "Latest",
   currentSearchTerm: "",
   debounceTimer: null,
 };

--- a/src/features/posts/filters.js
+++ b/src/features/posts/filters.js
@@ -52,6 +52,16 @@ export function applyFilterAndRender() {
         p.content.toLowerCase().includes(q)
     );
   }
+
+  // sort posts
+  if (state.currentSort === "Latest") {
+    items = items.slice().sort((a, b) => (b.createdAt || 0) - (a.createdAt || 0));
+  } else if (state.currentSort === "Oldest") {
+    items = items.slice().sort((a, b) => (a.createdAt || 0) - (b.createdAt || 0));
+  } else if (state.currentSort === "Most Popular") {
+    const score = (p) => (p.upvotes || 0) + (Array.isArray(p.children) ? p.children.length : 0);
+    items = items.slice().sort((a, b) => score(b) - score(a));
+  }
   if (items.length === 0) {
     $("#forum-root").html(
       '<div class="empty-state text-center p-4">No posts found.</div>'
@@ -75,6 +85,12 @@ $("#file-filter-btn").on("click", function (e) {
   $(".file-filter").toggleClass("open");
 });
 
+// toggle sort menu
+$("#sort-filter-btn").on("click", function (e) {
+  e.stopPropagation();
+  $(".sort-filter").toggleClass("open");
+});
+
 // pick a file type
 $(document).on("click", "#file-filter-menu li", function () {
   const type = $(this).data("type");
@@ -90,10 +106,28 @@ $(document).on("click", "#file-filter-menu li", function () {
   applyFilterAndRender();
 });
 
+// pick a sort type
+$(document).on("click", "#sort-filter-menu li", function () {
+  const sort = $(this).data("sort");
+  state.currentSort = sort;
+
+  // update button label & active menu item
+  $("#sort-filter-btn").text(sort + " ▾");
+  $("#sort-filter-menu li").removeClass("active");
+  $(this).addClass("active");
+
+  // close dropdown and re-render
+  $(".sort-filter").removeClass("open");
+  applyFilterAndRender();
+});
+
 // click outside to close
 $(document).on("click", function (e) {
   if (!$(e.target).closest(".file-filter").length) {
     $(".file-filter").removeClass("open");
+  }
+  if (!$(e.target).closest(".sort-filter").length) {
+    $(".sort-filter").removeClass("open");
   }
 });
 

--- a/src/ui/render.js
+++ b/src/ui/render.js
@@ -78,6 +78,7 @@ export function mapItem(raw, depth = 0) {
     depth,
     authorName: raw.Author?.display_name || "Anonymous",
     authorImage: raw.Author?.profile_image || DEFAULT_AVATAR,
+    createdAt,
     timeAgo: createdAt ? timeAgo(createdAt) : "",
     content: raw.post_copy ?? raw.comment ?? "",
     upvotes: postUpvotes.length + commentUpvotes.length,


### PR DESCRIPTION
## Summary
- track current sort order in config
- expose creation date in post items
- add UI dropdown for sorting posts
- style the new sort dropdown
- sort posts in `applyFilterAndRender` and add handlers

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_684028b59ab48321a5304702ce844fff