### PR TITLE
Add emoji picker to post and comment forms

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -62,6 +62,21 @@
       data-placeholder="Write a post..."></div>
     <div class="upload-section">
       <div class="flex item-center gap-4 my-4">
+        <div class="emoji-wrapper relative">
+          <button type="button" class="emoji-toggle">😊</button>
+          <div class="emoji-picker hidden absolute bg-white border rounded shadow-md p-1 mt-1 z-10">
+            <span class="cursor-pointer px-1">😀</span>
+            <span class="cursor-pointer px-1">😂</span>
+            <span class="cursor-pointer px-1">😍</span>
+            <span class="cursor-pointer px-1">😎</span>
+            <span class="cursor-pointer px-1">🤔</span>
+            <span class="cursor-pointer px-1">😢</span>
+            <span class="cursor-pointer px-1">👍</span>
+            <span class="cursor-pointer px-1">🎉</span>
+            <span class="cursor-pointer px-1">🚀</span>
+            <span class="cursor-pointer px-1">🥳</span>
+          </div>
+        </div>
         <button id="recordBtn" class="recordBtn">🎙 Start Recording</button>
         <button id="submit-post">Post</button>
       </div>

--- a/src/features/posts/actions.js
+++ b/src/features/posts/actions.js
@@ -22,6 +22,7 @@ import {
   setPendingFile,
   setFileTypeCheck,
 } from '../uploads/handlers.js';
+import { emojiPickerHtml } from '../../ui/emoji.js';
 import { tribute } from '../../utils/tribute.js';
 import { initFilePond } from '../../utils/filePond.js';
 import { processFileFields } from '../../utils/handleFile.js';
@@ -55,6 +56,7 @@ $(document).on("click", ".btn-comment", function (e) {
       <div class="editor min-h-[80px] resize-y p-2 rounded" contenteditable="true" data-placeholder="Write a reply...">${mentionHtml}</div>
       <div class="upload-section w-full mt-2 flex flex-col gap-2">
         <div class="flex items-center gap-2">
+        ${emojiPickerHtml}
         <button id="recordBtn" class="recordBtn">🎙 Start Recording</button>
         <button class="btn-submit-comment" data-uid="${uid}">Post</button>
         </div>

--- a/src/main.js
+++ b/src/main.js
@@ -18,6 +18,7 @@ import { tribute } from './utils/tribute.js';
 import { initFilePond, resumeAudioContext } from './utils/filePond.js';
 import { initNotifications } from './features/notifications/index.js';
 import './features/uploads/handlers.js';
+import { initEmojiHandlers } from './ui/emoji.js';
 
 export function connect() {
   state.socket = new WebSocket(WS_ENDPOINT, PROTOCOL);
@@ -131,6 +132,7 @@ window.addEventListener('DOMContentLoaded', () => {
   initFilePond();
   connect();
   initNotifications();
+  initEmojiHandlers();
 });
 
 window.addEventListener('touchstart', () => {

--- a/src/ui/emoji.js
+++ b/src/ui/emoji.js
@@ -1,0 +1,44 @@
+export const emojiPickerHtml = `
+  <div class="emoji-wrapper relative">
+    <button type="button" class="emoji-toggle">😊</button>
+    <div class="emoji-picker hidden absolute bg-white border rounded shadow-md p-1 mt-1 z-10">
+      <span class="cursor-pointer px-1">😀</span>
+      <span class="cursor-pointer px-1">😂</span>
+      <span class="cursor-pointer px-1">😍</span>
+      <span class="cursor-pointer px-1">😎</span>
+      <span class="cursor-pointer px-1">🤔</span>
+      <span class="cursor-pointer px-1">😢</span>
+      <span class="cursor-pointer px-1">👍</span>
+      <span class="cursor-pointer px-1">🎉</span>
+      <span class="cursor-pointer px-1">🚀</span>
+      <span class="cursor-pointer px-1">🥳</span>
+    </div>
+  </div>
+`;
+
+export function initEmojiHandlers() {
+  $(document).on('click', '.emoji-toggle', function (e) {
+    e.stopPropagation();
+    const picker = $(this).siblings('.emoji-picker');
+    $('.emoji-picker').not(picker).hide();
+    picker.toggle();
+  });
+
+  $(document).on('click', function (e) {
+    if (!$(e.target).closest('.emoji-picker, .emoji-toggle').length) {
+      $('.emoji-picker').hide();
+    }
+  });
+
+  $(document).on('click', '.emoji-picker span', function () {
+    const emoji = $(this).text();
+    const container = $(this).closest('.comment-form, .post-form');
+    const editor = container.find('.editor')[0];
+    if (editor) insertEmoji(editor, emoji);
+  });
+}
+
+function insertEmoji(editor, emoji) {
+  editor.focus();
+  document.execCommand('insertText', false, emoji);
+}


### PR DESCRIPTION
## Summary
- add emoji button and menu to post and comment creation
- implement generic emoji picker handlers
- activate emoji handlers on app load

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68403339e3a48321a25f8fe55f2e6569