### PR TITLE
Fix cursor position after emoji insert

### DIFF
--- a/src/features/posts/actions.js
+++ b/src/features/posts/actions.js
@@ -23,6 +23,7 @@ import {
   setFileTypeCheck,
 } from '../uploads/handlers.js';
 import { emojiPickerHtml } from '../../ui/emoji.js';
+import { moveCursorToEnd } from '../../utils/caret.js';
 import { tribute } from '../../utils/tribute.js';
 import { initFilePond } from '../../utils/filePond.js';
 import { processFileFields } from '../../utils/handleFile.js';
@@ -78,7 +79,9 @@ $(document).on("click", ".btn-comment", function (e) {
     // scroll to the newly inserted textarea so it's in view
     requestAnimationFrame(() => {
       inserted[0].scrollIntoView({ behavior: "smooth", block: "center" });
-      editorEl?.focus();
+      if (editorEl) {
+        moveCursorToEnd(editorEl);
+      }
     });
   }
 });

--- a/src/ui/emoji.js
+++ b/src/ui/emoji.js
@@ -16,7 +16,12 @@ export const emojiPickerHtml = `
   </div>
 `;
 
+import { saveSelection, restoreSelection } from '../utils/caret.js';
+
 export function initEmojiHandlers() {
+  $(document).on('focus keyup mouseup', '.editor', function () {
+    saveSelection();
+  });
   $(document).on('click', '.emoji-toggle', function (e) {
     e.stopPropagation();
     const picker = $(this).siblings('.emoji-picker');
@@ -40,5 +45,7 @@ export function initEmojiHandlers() {
 
 function insertEmoji(editor, emoji) {
   editor.focus();
+  restoreSelection(editor);
   document.execCommand('insertText', false, emoji);
+  saveSelection();
 }

--- a/src/utils/caret.js
+++ b/src/utils/caret.js
@@ -1,0 +1,28 @@
+let savedRange = null;
+
+export function saveSelection() {
+  const sel = window.getSelection();
+  if (sel && sel.rangeCount > 0) {
+    savedRange = sel.getRangeAt(0).cloneRange();
+  }
+}
+
+export function restoreSelection(el) {
+  if (!savedRange) return;
+  const sel = window.getSelection();
+  if (el.contains(savedRange.startContainer)) {
+    sel.removeAllRanges();
+    sel.addRange(savedRange);
+  }
+}
+
+export function moveCursorToEnd(el) {
+  const range = document.createRange();
+  range.selectNodeContents(el);
+  range.collapse(false);
+  const sel = window.getSelection();
+  sel.removeAllRanges();
+  sel.addRange(range);
+  el.focus();
+  savedRange = range.cloneRange();
+}


### PR DESCRIPTION
## Summary
- track caret position for editable areas
- restore the caret when inserting emojis
- move cursor to end of mention when opening a comment form

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6840349b10f88321988f63b1aa1fbde6