### PR TITLE
Fix emoji picker spacing

### DIFF
--- a/public/styles/style.css
+++ b/public/styles/style.css
@@ -119,6 +119,12 @@ button {
   font-weight: bold;
 }
 
+/* Display emojis in a horizontal row with spacing */
+.emoji-picker {
+  display: flex;
+  gap: 8px;
+}
+
 .clearIcon.hidden {
   display: none;
 }


### PR DESCRIPTION
## Summary
- show emojis in a horizontal row with 8px gap

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_684034d89de88321a27b484c05c54034