### PR TITLE
Fix emoji picker cursor retention

### DIFF
--- a/src/ui/emoji.js
+++ b/src/ui/emoji.js
@@ -19,7 +19,7 @@ export const emojiPickerHtml = `
 import { saveSelection, restoreSelection } from '../utils/caret.js';
 
 export function initEmojiHandlers() {
-  $(document).on('focus keyup mouseup', '.editor', function () {
+  $(document).on('keyup mouseup input', '.editor', function () {
     saveSelection();
   });
   $(document).on('click', '.emoji-toggle', function (e) {


### PR DESCRIPTION
## Summary
- avoid overwriting saved caret location when emoji widget refocuses the editor

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6840365b2334832182c437be97dc8649