### PR TITLE
Fix emoji picker display using flex

### DIFF
--- a/src/ui/emoji.js
+++ b/src/ui/emoji.js
@@ -25,13 +25,13 @@ export function initEmojiHandlers() {
   $(document).on('click', '.emoji-toggle', function (e) {
     e.stopPropagation();
     const picker = $(this).siblings('.emoji-picker');
-    $('.emoji-picker').not(picker).hide();
-    picker.toggle();
+    $('.emoji-picker').not(picker).addClass('hidden');
+    picker.toggleClass('hidden');
   });
 
   $(document).on('click', function (e) {
     if (!$(e.target).closest('.emoji-picker, .emoji-toggle').length) {
-      $('.emoji-picker').hide();
+      $('.emoji-picker').addClass('hidden');
     }
   });
 


### PR DESCRIPTION
## Summary
- ensure emoji picker toggles `hidden` class instead of jQuery `show/hide`

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_b_684036b77780832194347e0c675ec456