### PR TITLE
Fix link rendering

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -164,7 +164,7 @@
           <span class="timestamp text-sm text-[#65676b] ml-2">{{:timeAgo}}</span>
         </div>
       </div>
-      <div class="content my-2">{{:content}}</div>
+      <div class="content my-2">{{>content}}</div>
       <div class="file-preview">
         {{if depth === 0}}
           {{if fileContent}}


### PR DESCRIPTION
## Summary
- render post content as HTML instead of text so links display correctly

## Testing
- `npm test` *(fails: no `package.json` found)*

------
https://chatgpt.com/codex/tasks/task_b_684038e590388321af6a33f03b23c15c