### PR TITLE
Fix hyperlink formatting

### DIFF
--- a/src/utils/formatter.js
+++ b/src/utils/formatter.js
@@ -37,7 +37,8 @@ export function formatContent(html = "") {
   });
 
   // replace bare urls
-  const urlRegex = /(https?:\/\/[^\s<]+)/g;
+  // avoid matching URLs inside HTML attributes or within anchor text
+  const urlRegex = /(?<!["'=]|>)(https?:\/\/[^\s<]+)/g;
   html = html.replace(urlRegex, (url) => {
     const embed = buildEmbed(url);
     const anchor = `<a href="${url}" target="_blank" rel="noopener noreferrer">${url}</a>`;


### PR DESCRIPTION
## Summary
- prevent `formatContent` from mangling existing hyperlinks

## Testing
- `node - <<'NODE'
const { formatContent } = require('./src/utils/formatter.js');
console.log('Case 1:', formatContent('<p><a href="google.com">link</a></p>'));
console.log('Case 2:', formatContent('<p><a href="https://google.com">link</a></p>'));
console.log('Case 3:', formatContent('go to https://example.com for more info'));
NODE`

------
https://chatgpt.com/codex/tasks/task_b_68403a5fe1488321b9dd23556d60616b