### PR TITLE
Fix post modal UX and author details

### DIFF
--- a/public/styles/style.css
+++ b/public/styles/style.css
@@ -289,6 +289,11 @@ button {
 #create-post-modal.show {
   display: flex;
 }
+#submit-post {
+  position: absolute;
+  bottom: 1rem;
+  right: 1rem;
+}
 #file-preview-modal img,
 #file-preview-modal video,
 #file-preview-modal audio,

--- a/src/config.js
+++ b/src/config.js
@@ -48,6 +48,7 @@ export const state = {
   currentSort: "Latest",
   currentSearchTerm: "",
   debounceTimer: null,
+  currentUser: null,
 };
 export const searchInput = document.getElementById("searchPost");
 export const clearIcon = document.querySelector(".clearIcon");

--- a/src/features/posts/actions.js
+++ b/src/features/posts/actions.js
@@ -14,6 +14,7 @@ import {
 import {
   state,
   GLOBAL_AUTHOR_ID,
+  DEFAULT_AVATAR,
 } from '../../config.js';
 import { findNode, tmpl, mapItem } from '../../ui/render.js';
 import {
@@ -239,6 +240,12 @@ $(document).on("click", "#submit-post", async function () {
     const res = await fetchGraphQL(CREATE_POST_MUTATION, { payload: finalPayload });
     const raw = res.data?.createForumPost;
     if (raw) {
+      if (!raw.Author) {
+        raw.Author = {
+          display_name: state.currentUser?.display_name || 'Anonymous',
+          profile_image: state.currentUser?.profile_image || DEFAULT_AVATAR,
+        };
+      }
       const newNode = mapItem(raw, 0);
       newNode.isCollapsed = false;
       state.postsStore.unshift(newNode);
@@ -247,6 +254,7 @@ $(document).on("click", "#submit-post", async function () {
       state.rawComments = flattenComments(state.rawPosts);
       applyFilterAndRender();
       showToast("Post created");
+      $("#create-post-modal").addClass("hidden").removeClass("show");
     }
     editor.html("");
     setPendingFile(null);
@@ -318,6 +326,12 @@ $(document).on("click", ".btn-submit-comment", async function () {
     const res = await fetchGraphQL(CREATE_COMMENT_MUTATION, { payload: finalPayload });
     const raw = res.data?.createForumComment;
     if (raw) {
+      if (!raw.Author) {
+        raw.Author = {
+          display_name: state.currentUser?.display_name || 'Anonymous',
+          profile_image: state.currentUser?.profile_image || DEFAULT_AVATAR,
+        };
+      }
       const newComment = mapItem(raw, node.depth + 1);
       newComment.isCollapsed = false;
       node.children.push(newComment);

--- a/src/main.js
+++ b/src/main.js
@@ -6,6 +6,8 @@ import {
   KEEPALIVE_MS,
   MAX_BACKOFF,
   INACTIVITY_MS,
+  GLOBAL_AUTHOR_ID,
+  DEFAULT_AVATAR,
 } from './config.js';
 import { GQL_QUERY, FETCH_CONTACTS_QUERY } from './api/queries.js';
 import { safeArray } from './utils/formatter.js';
@@ -128,6 +130,13 @@ window.addEventListener('DOMContentLoaded', () => {
       value: c.Contact_ID,
       image: c.Profile_Image,
     }));
+    const current = contacts.find((c) => c.Contact_ID === GLOBAL_AUTHOR_ID);
+    if (current) {
+      state.currentUser = {
+        display_name: current.Display_Name || 'Anonymous',
+        profile_image: current.Profile_Image || DEFAULT_AVATAR,
+      };
+    }
   });
   initPosts();
   initFilePond();


### PR DESCRIPTION
## Summary
- pin the Post button to the bottom right of the modal
- track current user details in `state`
- store current user profile when loading contacts
- ensure newly created posts/comments have author info
- auto-close the post modal after posting

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6841212a70948321be8718d58d88c932