### PR TITLE
Fix anchor regex and add tests for quoting styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,6 @@
+{
+  "type": "module",
+  "scripts": {
+    "test": "node test/formatter.test.js"
+  }
+}

--- a/src/utils/formatter.js
+++ b/src/utils/formatter.js
@@ -32,8 +32,8 @@ export function formatContent(html = "") {
   html = decodeEntities(html);
   // convert anchor tags to open in new tab
   // if the link text is the url itself, also embed previews
-  const anchorRegex = /<a\s+[^>]*href="([^"]+)"[^>]*>(.*?)<\/a>/gi;
-  html = html.replace(anchorRegex, (match, url, text) => {
+  const anchorRegex = /<a\s+[^>]*href=(['"])([^'"<>]+)\1[^>]*>(.*?)<\/a>/gi;
+  html = html.replace(anchorRegex, (match, _quote, url, text) => {
     let normalized = url;
     if (!/^https?:\/\//i.test(url)) {
       normalized = `https://${url}`;

--- a/test/formatter.test.js
+++ b/test/formatter.test.js
@@ -1,0 +1,32 @@
+import assert from 'assert';
+import { formatContent } from '../src/utils/formatter.js';
+
+// Minimal document stub for decodeEntities
+global.document = {
+  createElement() {
+    return {
+      innerHTML: '',
+      get value() { return this.innerHTML; }
+    };
+  }
+};
+
+action();
+
+function action() {
+  testDoubleQuotedHref();
+  testSingleQuotedHref();
+  console.log('All tests passed');
+}
+
+function testDoubleQuotedHref() {
+  const input = '<p>Go to <a href="https://example.com">Example</a></p>';
+  const output = formatContent(input);
+  assert.ok(/<a href="https:\/\/example.com" target="_blank" rel="noopener noreferrer">Example<\/a>/.test(output));
+}
+
+function testSingleQuotedHref() {
+  const input = "<p>Go to <a href='https://example.com'>Example</a></p>";
+  const output = formatContent(input);
+  assert.ok(/<a href="https:\/\/example.com" target="_blank" rel="noopener noreferrer">Example<\/a>/.test(output));
+}


### PR DESCRIPTION
## Summary
- update anchor regex to accept single- or double-quoted hrefs
- add simple Node-based test suite
- verify both quoting styles create links with `target="_blank"` and `rel="noopener noreferrer"`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6841206f39708321abd1e9ba2cb36126