### PR TITLE
Remove lookbehind in URL regex

### DIFF
--- a/src/utils/formatter.js
+++ b/src/utils/formatter.js
@@ -44,12 +44,13 @@ export function formatContent(html = "") {
 
   // replace bare urls including those without protocol
   // avoid matching URLs inside HTML attributes or within anchor text
-  const urlRegex = /(?<!["'=]|>)(https?:\/\/|www\.)[^\s<]+/g;
-  html = html.replace(urlRegex, (raw) => {
+  // capture any leading character so we can reinsert it during replacement
+  const urlRegex = /(^|[^"'>=])((?:https?:\/\/|www\.)[^\s<]+)/g;
+  html = html.replace(urlRegex, (match, prefix, raw) => {
     const url = /^https?:\/\//i.test(raw) ? raw : `https://${raw}`;
     const embed = buildEmbed(url);
     const anchor = `<a href="${url}" target="_blank" rel="noopener noreferrer">${raw}</a>`;
-    return anchor + (embed || "");
+    return (prefix || "") + anchor + (embed || "");
   });
   return html;
 }

--- a/tests/formatter.test.mjs
+++ b/tests/formatter.test.mjs
@@ -1,0 +1,32 @@
+import assert from 'assert';
+import { formatContent } from '../src/utils/formatter.js';
+
+// Minimal DOM stub for decodeEntities
+global.document = {
+  createElement: () => {
+    return {
+      _value: '',
+      get innerHTML() { return this._value; },
+      set innerHTML(v) { this._value = v; this.value = v; },
+      value: ''
+    };
+  }
+};
+
+function runTest(description, input, expectedSubstring) {
+  const result = formatContent(input);
+  assert.ok(result.includes(expectedSubstring), `${description}: expected '${expectedSubstring}' in '${result}'`);
+}
+
+try {
+  runTest('http url in sentence', 'Check http://example.com now', '<a href="http://example.com"');
+  runTest('www url in sentence', 'Visit www.example.com today', '<a href="https://www.example.com"');
+  runTest('url at start with punctuation', '(http://example.com)', '<a href="http://example.com)"');
+  const linked = '<a href="http://example.com">http://example.com</a>';
+  const processed = formatContent(linked);
+  assert.ok(processed.startsWith('<a href="http://example.com"'), 'existing anchor preserved');
+  console.log('All tests passed');
+} catch (err) {
+  console.error(err);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- update `formatContent` to avoid look-behind in URL detection
- add tests for `formatContent` to validate link handling

## Testing
- `node tests/formatter.test.mjs`

------
https://chatgpt.com/codex/tasks/task_b_6841206b59b483218e06f5a4b1e84fc1