### PR TITLE
Fix HTML decoding and improve tests

### DIFF
--- a/src/utils/formatter.js
+++ b/src/utils/formatter.js
@@ -30,6 +30,8 @@ export function parseDate(timestamp) {
 export function formatContent(html = "") {
   if (!html) return "";
   html = decodeEntities(html);
+  // remove mention wrappers
+  html = html.replace(/<span[^>]*class=["']mention[^>]*>(.*?)<\/span>/gi, "$1");
   // convert anchor tags to open in new tab
   // if the link text is the url itself, also embed previews
   const anchorRegex = /<a\s+[^>]*href=(['"])([^'"<>]+)\1[^>]*>(.*?)<\/a>/gi;
@@ -80,8 +82,16 @@ function buildEmbed(url) {
 }
 
 function decodeEntities(str) {
-  const textarea = document.createElement("textarea");
-  textarea.innerHTML = str;
-  return textarea.value;
+  if (typeof document !== "undefined" && document.createElement) {
+    const div = document.createElement("div");
+    div.innerHTML = str;
+    return div.textContent || div.innerText || "";
+  }
+  return str
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&amp;/g, "&")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'");
 }
 

--- a/test/formatter.test.js
+++ b/test/formatter.test.js
@@ -1,21 +1,15 @@
 import assert from 'assert';
 import { formatContent } from '../src/utils/formatter.js';
 
-// Minimal document stub for decodeEntities
-global.document = {
-  createElement() {
-    return {
-      innerHTML: '',
-      get value() { return this.innerHTML; }
-    };
-  }
-};
+// No DOM needed for decodeEntities in tests
 
 action();
 
 function action() {
   testDoubleQuotedHref();
   testSingleQuotedHref();
+  testDecodeEntities();
+  testMentionStrip();
   console.log('All tests passed');
 }
 
@@ -29,4 +23,16 @@ function testSingleQuotedHref() {
   const input = "<p>Go to <a href='https://example.com'>Example</a></p>";
   const output = formatContent(input);
   assert.ok(/<a href="https:\/\/example.com" target="_blank" rel="noopener noreferrer">Example<\/a>/.test(output));
+}
+
+function testDecodeEntities() {
+  const input = '&lt;b&gt;&lt;i&gt;a&lt;/i&gt;&lt;/b&gt;';
+  const output = formatContent(input);
+  assert.ok(output.includes('<b><i>a</i></b>'));
+}
+
+function testMentionStrip() {
+  const input = '<span class="mention" data-mention-id="1">@foo</span>';
+  const output = formatContent(input);
+  assert.ok(output.includes('@foo') && !output.includes('<span'));
 }

--- a/tests/formatter.test.mjs
+++ b/tests/formatter.test.mjs
@@ -1,17 +1,7 @@
 import assert from 'assert';
 import { formatContent } from '../src/utils/formatter.js';
 
-// Minimal DOM stub for decodeEntities
-global.document = {
-  createElement: () => {
-    return {
-      _value: '',
-      get innerHTML() { return this._value; },
-      set innerHTML(v) { this._value = v; this.value = v; },
-      value: ''
-    };
-  }
-};
+// No DOM needed for decodeEntities in tests
 
 function runTest(description, input, expectedSubstring) {
   const result = formatContent(input);
@@ -25,6 +15,8 @@ try {
   const linked = '<a href="http://example.com">http://example.com</a>';
   const processed = formatContent(linked);
   assert.ok(processed.startsWith('<a href="http://example.com"'), 'existing anchor preserved');
+  runTest('formatted text preserved', '&lt;b&gt;&lt;i&gt;a&lt;/i&gt;&lt;/b&gt;', '<b><i>a</i></b>');
+  runTest('mention stripped', '<span class="mention" data-mention-id="1">@foo</span>', '@foo');
   console.log('All tests passed');
 } catch (err) {
   console.error(err);


### PR DESCRIPTION
## Summary
- ensure mention spans are removed when formatting content
- decode HTML entities properly across environments
- expand unit tests for formatted content and mentions

## Testing
- `npm test`
- `node tests/formatter.test.mjs`

------
https://chatgpt.com/codex/tasks/task_b_68412701ebec8321b6d505f2591bab90