### PR TITLE
Require login before loading forum

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -182,8 +182,8 @@ window.addEventListener('DOMContentLoaded', () => {
   let initialized = false;
 
   function init(id) {
-    if (!initialized) {
-      if (id) setGlobalAuthorId(id);
+    if (!initialized && id) {
+      setGlobalAuthorId(id);
       loginModal?.classList.add('hidden');
       startApp();
       initialized = true;
@@ -196,7 +196,7 @@ window.addEventListener('DOMContentLoaded', () => {
   });
 
   closeLoginBtn?.addEventListener('click', () => {
-    init();
+    loginModal?.classList.add('hidden');
   });
 });
 


### PR DESCRIPTION
## Summary
- require user ID entry before starting the forum
- close button only hides the login modal

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68416678edb08321bb2294355c8ce68d