### PR TITLE
Handle UI updates locally

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -53,6 +53,7 @@ export const state = {
   debounceTimer: null,
   currentUser: null,
   initialPostsLoaded: false,
+  ignoreNextSocketUpdate: false,
 };
 export const searchInput = document.getElementById("searchPost");
 export const clearIcon = document.querySelector(".clearIcon");

--- a/src/features/posts/actions.js
+++ b/src/features/posts/actions.js
@@ -216,6 +216,7 @@ $(document).on("click", "#delete-confirm", function () {
       state.rawComments = flattenComments(state.rawPosts);
       $(`[data-uid="${uid}"]`).closest('.item').remove();
       showToast("Deleted");
+      state.ignoreNextSocketUpdate = true;
     })
     .catch((err) => {
       console.error("Delete failed", err);
@@ -314,6 +315,7 @@ $(document).on("click", "#submit-post", async function () {
       state.rawPosts.unshift(raw);
       state.rawComments = flattenComments(state.rawPosts);
       applyFilterAndRender();
+      state.ignoreNextSocketUpdate = true;
       showToast("Post created");
       $("#create-post-modal").addClass("hidden").removeClass("show");
     }
@@ -401,10 +403,11 @@ $(document).on("click", ".btn-submit-comment", async function () {
       if (parentRaw) {
         parentRaw.ForumComments = parentRaw.ForumComments || [];
         raw.ForumComments = [];
-        parentRaw.ForumComments.push(raw);
-        state.rawComments = flattenComments(state.rawPosts);
+      parentRaw.ForumComments.push(raw);
+      state.rawComments = flattenComments(state.rawPosts);
       }
       applyFilterAndRender();
+      state.ignoreNextSocketUpdate = true;
       showToast("Comment posted");
     }
     setPendingFile(null);

--- a/src/main.js
+++ b/src/main.js
@@ -55,7 +55,11 @@ export function connect() {
       state.rawComments = flattenComments(state.rawPosts);
       state.postsStore = buildTree(state.postsStore, state.rawPosts, state.rawComments);
       state.initialPostsLoaded = true;
-      applyFilterAndRender();
+      if (state.ignoreNextSocketUpdate) {
+        state.ignoreNextSocketUpdate = false;
+      } else {
+        applyFilterAndRender();
+      }
       requestAnimationFrame(() => {
         Plyr.setup('.js-player', {
           controls: [


### PR DESCRIPTION
## Summary
- add a state flag to skip the next subscription render
- set the flag after creating or deleting posts and comments
- use the flag in the subscription handler to avoid unnecessary rerenders

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684166127b9c832192fea01175830b16