### PR TITLE
Fix websocket reconnection loop

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -99,18 +99,9 @@ export function connect() {
       console.error("Subscription error", msg.payload);
     } else if (msg.type === "GQL_COMPLETE") {
       console.warn("Subscription complete");
-      // Some backends send GQL_COMPLETE after each mutation which would end the
-      // subscription without closing the socket. Re-subscribe using the same
-      // connection instead of waiting for a reconnect.
-      if (state.socket && state.socket.readyState === WebSocket.OPEN) {
-        state.socket.send(
-          JSON.stringify({
-            id: SUB_ID,
-            type: "GQL_START",
-            payload: { query: GQL_QUERY },
-          })
-        );
-      }
+      // Modern servers keep the connection open after sending GQL_COMPLETE.
+      // Avoid sending an extra GQL_START which previously caused the server
+      // to close the socket and trigger a reconnect.
     }
   });
   state.socket.addEventListener("error", (e) => {


### PR DESCRIPTION
## Summary
- avoid resubscribing on `GQL_COMPLETE` events

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68417dc252f88321bc646251c450ea30