### PR TITLE
Implement featured toggling and comment disabling UI

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -235,6 +235,9 @@
           <div class="info">
             <span class="name font-bold">{{:authorName}}</span>
             <span class="timestamp text-sm text-[#65676b] ml-2">{{:timeAgo}}</span>
+            {{if isFeatured}}
+            <i class="fa-solid fa-star text-yellow-500 ml-2" title="Featured"></i>
+            {{/if}}
           </div>
         </div>
            <div x-data="{ threeDotsForAdmin: false, openedWithKeyboard: false }" class="relative w-fit" x-on:keydown.esc.window="threeDotsForAdmin = false, openedWithKeyboard = false">
@@ -250,7 +253,11 @@
 
     <div class="cursor-pointer px-4 py-2 text-nowrap text-black transition-all hover:bg-[var(--primary)]" role="menuitem">Hide this post</div>
     <div data-uid="{{:uid}}" class="btn-delete cursor-pointer px-4 py-2 text-nowrap text-black transition-all hover:bg-[var(--primary)]" role="menuitem">Delete this post</div>
+    {{if !isFeatured}}
     <div data-uid="{{:uid}}" class="btn-feature cursor-pointer px-4 py-2 text-nowrap text-black transition-all hover:bg-[var(--primary)]" role="menuitem">Mark this post as featured</div>
+    {{else}}
+    <div data-uid="{{:uid}}" class="btn-unfeature cursor-pointer px-4 py-2 text-nowrap text-black transition-all hover:bg-[var(--primary)]" role="menuitem">Remove featured mark</div>
+    {{/if}}
     <div data-uid="{{:uid}}" class="btn-disable-comments cursor-pointer px-4 py-2 text-nowrap text-black transition-all hover:bg-[var(--primary)]" role="menuitem">Disable comments on this post</div>
     {{else}}
     <div data-uid="{{:uid}}" class="btn-delete cursor-pointer px-4 py-2 text-nowrap text-black transition-all hover:bg-[var(--primary)]" role="menuitem">Delete this post</div>
@@ -310,7 +317,9 @@
           <div class = "flex items-center justify-between">
             <div class = "flex items-center gap-4">
               <button class="btn-like{{:hasUpvoted ? ' liked' : ''}} flex items-center" data-uid="{{:uid}}"><i class="fa-solid fa-thumbs-up"></i> <span class="ml-1">{{:upvotes}}</span></button>
+              {{if !commentsDisabled}}
               <button class="btn-comment flex items-center" data-uid="{{:uid}}"><i class="fa-solid fa-comment"></i></button>
+              {{/if}}
             </div>
             {{if depth === 0}}
               <button class="btn-bookmark{{:hasBookmarked ? ' bookmarked' : ''}} flex items-center" data-uid="{{:uid}}"><i class="fa-solid fa-bookmark"></i></button>

--- a/src/features/posts/actions.js
+++ b/src/features/posts/actions.js
@@ -558,6 +558,28 @@ export function initPostHandlers() {
     }
   });
 
+  // UNMARK POST FEATURED
+  $(document).on("click", ".btn-unfeature", async function () {
+    const uid = $(this).data("uid");
+    const node = findNode(state.postsStore, uid);
+    if (!node) return;
+    $(this).addClass("state-disabled");
+    try {
+      await fetchGraphQL(UPDATE_FORUM_POST_MUTATION, {
+        id: node.id,
+        payload: { featured_forum: false },
+      });
+      node.isFeatured = false;
+      const rawItem = findRawById(state.rawItems, node.id);
+      if (rawItem) rawItem.featured_forum = false;
+      applyFilterAndRender();
+    } catch (err) {
+      console.error("Failed to unmark featured", err);
+    } finally {
+      $(this).removeClass("state-disabled");
+    }
+  });
+
   // DISABLE COMMENTS
   $(document).on("click", ".btn-disable-comments", async function () {
     const uid = $(this).data("uid");
@@ -571,6 +593,8 @@ export function initPostHandlers() {
       });
       const rawItem = findRawById(state.rawItems, node.id);
       if (rawItem) rawItem.disable_new_comments = true;
+      node.commentsDisabled = true;
+      applyFilterAndRender();
     } catch (err) {
       console.error("Failed to disable comments", err);
     } finally {

--- a/src/ui/render.js
+++ b/src/ui/render.js
@@ -102,6 +102,7 @@ export function mapItem(raw, depth = 0) {
     isCollapsed: true,
     parentId: raw.parent_forum_id,
     isFeatured: raw.featured_forum === true,
+    commentsDisabled: raw.disable_new_comments === true,
     fileType: raw.file_type || "None",
     fileContent: depth === 0 ? fileContent : "",
     fileContentName: depth === 0 ? fileName : "",


### PR DESCRIPTION
## Summary
- show a star icon on posts marked as featured
- allow admins to unmark featured posts
- store comment disable state and hide comment button when disabled

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68481052abd8832194135d0991ff205d