### PR TITLE
Add comment toggle menu and toast feedback

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -249,18 +249,27 @@
       </div>
   <!-- Dropdown Menu -->
   <div x-cloak x-show="threeDotsForAdmin || openedWithKeyboard" x-transition x-trap="openedWithKeyboard" x-on:click.outside="threeDotsForAdmin = false, openedWithKeyboard = false" x-on:keydown.down.prevent="$focus.wrap().next()" x-on:keydown.up.prevent="$focus.wrap().previous()" class="absolute top-11 left-0 flex w-fit min-w-48 flex-col overflow-hidden bg-white shadow-lg z-[999]" role="menu">
-    {{if isAdmin}}
-
-    <div class="cursor-pointer px-4 py-2 text-nowrap text-black transition-all hover:bg-[var(--primary)]" role="menuitem">Hide this post</div>
-    <div data-uid="{{:uid}}" class="btn-delete cursor-pointer px-4 py-2 text-nowrap text-black transition-all hover:bg-[var(--primary)]" role="menuitem">Delete this post</div>
-    {{if !isFeatured}}
-    <div data-uid="{{:uid}}" class="btn-feature cursor-pointer px-4 py-2 text-nowrap text-black transition-all hover:bg-[var(--primary)]" role="menuitem">Mark this post as featured</div>
+    {{if depth === 0}}
+      {{if isAdmin}}
+      <div class="cursor-pointer px-4 py-2 text-nowrap text-black transition-all hover:bg-[var(--primary)]" role="menuitem">Hide this post</div>
+      <div data-uid="{{:uid}}" class="btn-delete cursor-pointer px-4 py-2 text-nowrap text-black transition-all hover:bg-[var(--primary)]" role="menuitem">Delete this post</div>
+      {{if !isFeatured}}
+      <div data-uid="{{:uid}}" class="btn-feature cursor-pointer px-4 py-2 text-nowrap text-black transition-all hover:bg-[var(--primary)]" role="menuitem">Mark this post as featured</div>
+      {{else}}
+      <div data-uid="{{:uid}}" class="btn-unfeature cursor-pointer px-4 py-2 text-nowrap text-black transition-all hover:bg-[var(--primary)]" role="menuitem">Remove featured mark</div>
+      {{/if}}
+      {{if commentsDisabled}}
+      <div data-uid="{{:uid}}" class="btn-enable-comments cursor-pointer px-4 py-2 text-nowrap text-black transition-all hover:bg-[var(--primary)]" role="menuitem">Enable comments on this post</div>
+      {{else}}
+      <div data-uid="{{:uid}}" class="btn-disable-comments cursor-pointer px-4 py-2 text-nowrap text-black transition-all hover:bg-[var(--primary)]" role="menuitem">Disable comments on this post</div>
+      {{/if}}
+      {{else}}
+      <div data-uid="{{:uid}}" class="btn-delete cursor-pointer px-4 py-2 text-nowrap text-black transition-all hover:bg-[var(--primary)]" role="menuitem">Delete this post</div>
+      {{/if}}
     {{else}}
-    <div data-uid="{{:uid}}" class="btn-unfeature cursor-pointer px-4 py-2 text-nowrap text-black transition-all hover:bg-[var(--primary)]" role="menuitem">Remove featured mark</div>
-    {{/if}}
-    <div data-uid="{{:uid}}" class="btn-disable-comments cursor-pointer px-4 py-2 text-nowrap text-black transition-all hover:bg-[var(--primary)]" role="menuitem">Disable comments on this post</div>
-    {{else}}
-    <div data-uid="{{:uid}}" class="btn-delete cursor-pointer px-4 py-2 text-nowrap text-black transition-all hover:bg-[var(--primary)]" role="menuitem">Delete this post</div>
+      <div data-uid="{{:uid}}" class="btn-delete cursor-pointer px-4 py-2 text-nowrap text-black transition-all hover:bg-[var(--primary)]" role="menuitem">
+        {{if depth === 1}}Delete this comment{{else}}Delete this reply{{/if}}
+      </div>
     {{/if}}
   </div>
 </div>

--- a/src/features/posts/actions.js
+++ b/src/features/posts/actions.js
@@ -551,6 +551,7 @@ export function initPostHandlers() {
       const rawItem = findRawById(state.rawItems, node.id);
       if (rawItem) rawItem.featured_forum = true;
       applyFilterAndRender();
+      showToast("Marked as featured");
     } catch (err) {
       console.error("Failed to mark featured", err);
     } finally {
@@ -573,6 +574,7 @@ export function initPostHandlers() {
       const rawItem = findRawById(state.rawItems, node.id);
       if (rawItem) rawItem.featured_forum = false;
       applyFilterAndRender();
+      showToast("Removed featured mark");
     } catch (err) {
       console.error("Failed to unmark featured", err);
     } finally {
@@ -595,8 +597,32 @@ export function initPostHandlers() {
       if (rawItem) rawItem.disable_new_comments = true;
       node.commentsDisabled = true;
       applyFilterAndRender();
+      showToast("Comments disabled");
     } catch (err) {
       console.error("Failed to disable comments", err);
+    } finally {
+      $(this).removeClass("state-disabled");
+    }
+  });
+
+  // ENABLE COMMENTS
+  $(document).on("click", ".btn-enable-comments", async function () {
+    const uid = $(this).data("uid");
+    const node = findNode(state.postsStore, uid);
+    if (!node) return;
+    $(this).addClass("state-disabled");
+    try {
+      await fetchGraphQL(UPDATE_FORUM_POST_MUTATION, {
+        id: node.id,
+        payload: { disable_new_comments: false },
+      });
+      const rawItem = findRawById(state.rawItems, node.id);
+      if (rawItem) rawItem.disable_new_comments = false;
+      node.commentsDisabled = false;
+      applyFilterAndRender();
+      showToast("Comments enabled");
+    } catch (err) {
+      console.error("Failed to enable comments", err);
     } finally {
       $(this).removeClass("state-disabled");
     }


### PR DESCRIPTION
## Summary
- restrict comment menu options to delete only
- allow posts to toggle comments via enable/disable menu items
- show toasts when marking/unmarking featured and when toggling comments

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68481191ff90832184b4ac0771974f64