### PR TITLE
Fix duplicate spinner in user modal

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -65,14 +65,6 @@
             </div>
           </div>
           <div id="adminContacts" x-show="activeUserTab==='admins'" class="flex h-[100px] items-center justify-center">
-            <div class="flex w-12">
-              <div class="relative">
-                <div class="w-12 h-12 rounded-full absolute  border border-solid border-gray-200"></div>
-                <div
-                  class="w-12 h-12 rounded-full animate-spin absolute border border-solid border-yellow-500 border-t-transparent">
-                </div>
-              </div>
-            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- show only one loading spinner in the user selection modal

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684814af037c8321b88cb582b1a2f84e