### PR TITLE
Add unit tests and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,11 @@ Create a `src/config.js` file or provide the values as environment variables whe
 - **WS_ENDPOINT** – GraphQL WebSocket endpoint for real-time updates. Typically the same host as `HTTP_ENDPOINT` using `wss://` and appending `?apiKey=YOUR_API_KEY`.
 
 When running in the browser without a bundler, copy `src/config.example.js` to `src/config.js` and fill in your actual values. The repository's `.gitignore` already excludes `src/config.js` so your secrets stay out of version control.
+
+## Tests
+
+Run the unit tests with:
+
+```bash
+npm test
+```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "type": "module",
   "scripts": {
-    "test": "node test/formatter.test.js"
+    "test": "node --test"
   }
 }

--- a/test/formatter.test.js
+++ b/test/formatter.test.js
@@ -1,0 +1,30 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { safeArray, timeAgo, parseDate } from '../src/utils/formatter.js';
+
+
+test('safeArray returns an array or empty array', () => {
+  assert.deepStrictEqual(safeArray([1, 2]), [1, 2]);
+  assert.deepStrictEqual(safeArray(null), []);
+});
+
+test('timeAgo returns correct intervals', () => {
+  const originalNow = Date.now;
+  Date.now = () => new Date('2024-01-02T00:00:00Z').getTime();
+
+  assert.strictEqual(timeAgo(new Date('2024-01-01T23:59:00Z')), '1m ago');
+  assert.strictEqual(timeAgo(new Date('2024-01-01T23:00:00Z')), '1h ago');
+  assert.strictEqual(timeAgo(new Date('2024-01-01T00:00:00Z')), '1d ago');
+
+  Date.now = originalNow;
+});
+
+test('parseDate supports seconds and strings', () => {
+  const ts = 60; // seconds
+  assert.deepStrictEqual(parseDate(ts), new Date(ts * 1000));
+
+  const iso = '2020-01-01T00:00:00Z';
+  assert.deepStrictEqual(parseDate(iso), new Date(iso));
+  assert.strictEqual(parseDate(null), null);
+});

--- a/tests/formatter.test.mjs
+++ b/tests/formatter.test.mjs
@@ -1,0 +1,32 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { mergeObjects, mergeLists } from '../src/utils/merge.js';
+
+test('mergeObjects merges nested values', () => {
+  const oldObj = { a: 1, b: { c: 2 } };
+  const newObj = { b: { c: 3 }, d: 4 };
+  const expected = { a: 1, b: { c: 3 }, d: 4 };
+  assert.deepStrictEqual(mergeObjects(oldObj, newObj), expected);
+});
+
+test('mergeObjects skips null or undefined', () => {
+  const oldObj = { a: 1 };
+  const newObj = { a: null, b: undefined, c: 2 };
+  const expected = { a: 1, c: 2 };
+  assert.deepStrictEqual(mergeObjects(oldObj, newObj), expected);
+});
+
+test('mergeLists merges items by id', () => {
+  const oldList = [ { id: 1, val: 'a' }, { id: 2, val: 'b' } ];
+  const newList = [ { id: 2, val: 'c' }, { id: 3, val: 'd' } ];
+  const expected = [ { id: 1, val: 'a' }, { id: 2, val: 'c' }, { id: 3, val: 'd' } ];
+  assert.deepStrictEqual(mergeLists(oldList, newList), expected);
+});
+
+test('mergeObjects handles arrays via mergeLists', () => {
+  const oldObj = { items: [ { id: 1, v: 'a' } ] };
+  const newObj = { items: [ { id: 1, v: 'b' }, { id: 2, v: 'c' } ] };
+  const expected = { items: [ { id: 1, v: 'b' }, { id: 2, v: 'c' } ] };
+  assert.deepStrictEqual(mergeObjects(oldObj, newObj), expected);
+});


### PR DESCRIPTION
## Summary
- add tests for utils/formatter and utils/merge using Node's test runner
- configure `npm test` to use `node --test`
- document how to run the tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684bc3785b6483218f8b2067345753ad