### PR TITLE
Refactor main.js into smaller modules

### DIFF
--- a/src/notifications.js
+++ b/src/notifications.js
@@ -1,0 +1,184 @@
+import {
+  state,
+  PROTOCOL,
+  WS_ENDPOINT,
+  KEEPALIVE_MS,
+  MAX_BACKOFF,
+  NOTIF_SUB_ID,
+  GLOBAL_AUTHOR_ID
+} from "./config.js";
+import { GET_NOTIFICATIONS } from "./api/queries.js";
+import { fetchGraphQL } from "./api/fetch.js";
+
+const notificationTemplate = $.templates("#notificationTemplate");
+
+export function connectNotification() {
+  if (
+    state.notifIsConnecting ||
+    (state.notificationSocket &&
+      (state.notificationSocket.readyState === WebSocket.OPEN ||
+        state.notificationSocket.readyState === WebSocket.CONNECTING))
+  ) {
+    return;
+  }
+
+  state.notifIsConnecting = true;
+  state.notificationSocket = new WebSocket(WS_ENDPOINT, PROTOCOL);
+
+  const notifContainer = document.getElementById("notificationContainerSocket");
+  if (notifContainer) {
+    notifContainer.innerHTML = `
+      <div class="flex w-12 mx-auto my-6">
+        <div class="relative">
+          <div class="w-12 h-12 rounded-full absolute border border-solid border-gray-200"></div>
+          <div class="w-12 h-12 rounded-full animate-spin absolute border border-solid border-yellow-500 border-t-transparent"></div>
+        </div>
+      </div>`;
+  }
+
+  state.notificationSocket.addEventListener("open", () => {
+    state.notifBackoff = 1000;
+    state.notificationSocket.send(JSON.stringify({ type: "CONNECTION_INIT" }));
+
+    state.notifKeepAliveTimer = setInterval(() => {
+      state.notificationSocket.send(JSON.stringify({ type: "KEEP_ALIVE" }));
+    }, KEEPALIVE_MS);
+
+    state.notifIsConnecting = false;
+  });
+
+  state.notificationSocket.addEventListener("message", ({ data }) => {
+    let msg;
+    try {
+      msg = JSON.parse(data);
+    } catch {
+      console.error("Invalid JSON", data);
+      return;
+    }
+
+    if (msg.type === "CONNECTION_ACK") {
+      state.notificationSocket.send(
+        JSON.stringify({
+          id: NOTIF_SUB_ID,
+          type: "GQL_START",
+          payload: {
+            query: GET_NOTIFICATIONS,
+            variables: { author_id: GLOBAL_AUTHOR_ID, notified_contact_id: GLOBAL_AUTHOR_ID },
+          },
+        })
+      );
+    } else if (
+      msg.type === "GQL_DATA" &&
+      msg.id === NOTIF_SUB_ID &&
+      msg.payload?.data
+    ) {
+      const notifications = msg.payload.data.subscribeToAnnouncements;
+      const notifContainer = document.getElementById("notificationContainerSocket");
+
+      if (notifContainer) {
+        notifContainer.innerHTML = "";
+
+        if (!notifications || (Array.isArray(notifications) && notifications.length === 0)) {
+          notifContainer.innerHTML = `<div class="text-gray-500 text-sm p-4">No notifications</div>`;
+          return;
+        }
+
+        if (Array.isArray(notifications)) {
+          notifications.forEach((notif) => {
+            if (notif?.Title) {
+              const html = notificationTemplate.render(notif);
+              notifContainer.insertAdjacentHTML("beforeend", html);
+            }
+          });
+        } else if (notifications?.Title) {
+          const html = notificationTemplate.render(notifications);
+          notifContainer.insertAdjacentHTML("beforeend", html);
+        }
+      }
+    } else if (msg.type === "GQL_ERROR") {
+      console.error("Notification subscription error", msg.payload);
+    } else if (msg.type === "GQL_COMPLETE") {
+      if (
+        state.notificationSocket &&
+        state.notificationSocket.readyState === WebSocket.OPEN
+      ) {
+        state.notificationSocket.send(JSON.stringify({ type: "CONNECTION_TERMINATE" }));
+        state.notificationSocket.close();
+      }
+    }
+  });
+
+  state.notificationSocket.addEventListener("error", (e) => {
+    console.error("Notification WebSocket error", e);
+    state.notifIsConnecting = false;
+  });
+
+  state.notificationSocket.addEventListener("close", () => {
+    clearInterval(state.notifKeepAliveTimer);
+    state.notifKeepAliveTimer = null;
+    state.notificationSocket = null;
+    state.notifIsConnecting = false;
+    setTimeout(connectNotification, state.notifBackoff);
+    state.notifBackoff = Math.min(state.notifBackoff * 2, MAX_BACKOFF);
+  });
+}
+
+export function initNotificationEvents() {
+  document.addEventListener("click", async (e) => {
+    const markAll = e.target.id === "markAllNotificationAsRead";
+
+    let ids = [];
+
+    if (markAll) {
+      const container = document.getElementById("notificationContainerSocket");
+      const elements = container.querySelectorAll("[data-announcement].unread");
+      ids = Array.from(elements).map((el) => el.getAttribute("data-announcement"));
+    } else {
+      const unreadElements = document.querySelectorAll(".unread");
+      for (const el of unreadElements) {
+        if (el.contains(e.target)) {
+          const announcementId = el.getAttribute("data-announcement");
+          if (!announcementId) return;
+          ids = [announcementId];
+          break;
+        }
+      }
+    }
+
+    if (!ids.length) return;
+
+    const variables = {
+      payload: { is_read: true },
+    };
+
+    const UPDATE_ANNOUNCEMENT = `
+      mutation updateAnnouncements($payload: AnnouncementUpdateInput = null) {
+        updateAnnouncements(query: [{ whereIn: { id: [${ids.join(",")}] } }], payload: $payload) {
+          is_read
+        }
+      }
+    `;
+
+    try {
+      await fetchGraphQL(UPDATE_ANNOUNCEMENT, variables, UPDATE_ANNOUNCEMENT);
+
+      if (markAll) {
+        const container = document.getElementById("notificationContainerSocket");
+        const elements = container.querySelectorAll("[data-announcement].unread");
+        elements.forEach((el) => {
+          el.classList.remove("unread");
+          el.classList.add("read");
+        });
+      } else {
+        document.querySelectorAll(".unread").forEach((el) => {
+          if (ids.includes(el.getAttribute("data-announcement"))) {
+            el.classList.remove("unread");
+            el.classList.add("read");
+          }
+        });
+      }
+    } catch (error) {
+      console.error("Error marking announcement(s) as read:", error);
+    }
+  });
+}

--- a/src/ws.js
+++ b/src/ws.js
@@ -1,0 +1,145 @@
+import {
+  state,
+  PROTOCOL,
+  WS_ENDPOINT,
+  SUB_ID,
+  KEEPALIVE_MS,
+  MAX_BACKOFF,
+  INACTIVITY_MS,
+  GLOBAL_PAGE_TAG
+} from "./config.js";
+import { SUBSCRIBE_FORUM_POSTS } from "./api/queries.js";
+import { buildTree } from "./ui/render.js";
+import { mergeLists } from "./utils/merge.js";
+import { applyFilterAndRender } from "./features/posts/index.js";
+import { setupPlyr } from "./utils/plyr.js";
+
+let contactIncludedInTag = false;
+
+export function setContactIncludedInTag(val) {
+  contactIncludedInTag = val;
+}
+
+export function terminateAndClose() {
+  if (state.socket && state.socket.readyState === WebSocket.OPEN) {
+    state.socket.send(JSON.stringify({ type: "CONNECTION_TERMINATE" }));
+    state.socket.close();
+  }
+  if (
+    state.notificationSocket &&
+    state.notificationSocket.readyState === WebSocket.OPEN
+  ) {
+    state.notificationSocket.send(
+      JSON.stringify({ type: "CONNECTION_TERMINATE" })
+    );
+    state.notificationSocket.close();
+  }
+}
+
+export function connect() {
+  if (
+    state.isConnecting ||
+    (state.socket &&
+      (state.socket.readyState === WebSocket.OPEN ||
+        state.socket.readyState === WebSocket.CONNECTING))
+  ) {
+    return;
+  }
+  state.isConnecting = true;
+  state.socket = new WebSocket(WS_ENDPOINT, PROTOCOL);
+  state.socket.addEventListener("open", () => {
+    state.backoff = 1000;
+    state.socket.send(JSON.stringify({ type: "CONNECTION_INIT" }));
+    state.keepAliveTimer = setInterval(() => {
+      state.socket.send(JSON.stringify({ type: "KEEP_ALIVE" }));
+    }, KEEPALIVE_MS);
+    state.isConnecting = false;
+  });
+  state.socket.addEventListener("message", ({ data }) => {
+    let msg;
+    try {
+      msg = JSON.parse(data);
+    } catch {
+      console.error("Invalid JSON", data);
+      return;
+    }
+    if (msg.type === "CONNECTION_ACK") {
+      state.socket.send(
+        JSON.stringify({
+          id: SUB_ID,
+          type: "GQL_START",
+          payload: {
+            query: SUBSCRIBE_FORUM_POSTS,
+            variables: { forum_tag: GLOBAL_PAGE_TAG }
+          }
+        })
+      );
+    } else if (
+      msg.type === "GQL_DATA" &&
+      msg.id === SUB_ID &&
+      msg.payload?.data
+    ) {
+      const incoming = msg.payload.data.subscribeToForumPosts ?? [];
+      state.rawItems = mergeLists(state.rawItems, incoming);
+      state.postsStore = buildTree(state.postsStore, state.rawItems);
+      state.initialPostsLoaded = true;
+      if (state.ignoreNextSocketUpdate) {
+        state.ignoreNextSocketUpdate = false;
+      } else {
+        applyFilterAndRender();
+      }
+      requestAnimationFrame(setupPlyr);
+    } else if (msg.type === "GQL_ERROR") {
+      console.error("Subscription error", msg.payload);
+    } else if (msg.type === "GQL_COMPLETE") {
+      console.warn("Subscription complete");
+      if (state.socket && state.socket.readyState === WebSocket.OPEN) {
+        state.socket.send(JSON.stringify({ type: "CONNECTION_TERMINATE" }));
+        state.socket.close();
+      }
+    }
+  });
+  state.socket.addEventListener("error", e => {
+    console.error("WebSocket error", e);
+    state.isConnecting = false;
+  });
+  state.socket.addEventListener("close", () => {
+    clearInterval(state.keepAliveTimer);
+    state.keepAliveTimer = null;
+    state.socket = null;
+    state.isConnecting = false;
+    setTimeout(connect, state.backoff);
+    state.backoff = Math.min(state.backoff * 2, MAX_BACKOFF);
+  });
+}
+
+let inactivityTimer;
+
+function handleVisibilityChange() {
+  if (document.hidden) {
+    clearTimeout(inactivityTimer);
+    inactivityTimer = setTimeout(() => {
+      clearInterval(state.keepAliveTimer);
+      terminateAndClose();
+    }, INACTIVITY_MS);
+  } else {
+    clearTimeout(inactivityTimer);
+    if (!state.socket || state.socket.readyState === WebSocket.CLOSED) {
+      if (contactIncludedInTag) {
+        connect();
+      } else {
+        console.log("Contact not included in tag, skipping connection.");
+      }
+    } else if (!state.keepAliveTimer) {
+      state.keepAliveTimer = setInterval(() => {
+        if (state.socket.readyState === WebSocket.OPEN) {
+          state.socket.send(JSON.stringify({ type: "KEEP_ALIVE" }));
+        }
+      }, KEEPALIVE_MS);
+    }
+  }
+}
+
+export function initWebSocketHandlers() {
+  document.addEventListener("visibilitychange", handleVisibilityChange);
+}


### PR DESCRIPTION
## Summary
- split websocket logic into `ws.js`
- move notification websocket + read handlers to `notifications.js`
- create `domEvents.js` for DOM bindings
- trim `main.js` so it focuses on app init

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684bc37b9e4883218d09826cfba10877