### PR TITLE
Move secrets to env file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+API_KEY=YOUR_API_KEY
+AWS_PARAM=YOUR_AWS_PARAM
+AWS_PARAM_URL=https://your-domain.com/s/aws
+HTTP_ENDPOINT=https://your-domain.com/api/v1/graphql
+WS_ENDPOINT=wss://your-domain.com/api/v1/graphql?apiKey=YOUR_API_KEY

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ Desktop.ini
 *.tmp
 *.temp
 src/config.js
+.env

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ the browser can verify the SRI hash correctly.
 
 ## Configuration
 
-Create a `src/config.js` file or provide the values as environment variables when bundling. A template is available at `src/config.example.js`.
+Configuration values are read in `src/config.js` from environment variables at build time or from `window.APP_CONFIG` at runtime. Create a `.env` file at the project root or provide the values through your bundler's environment. An example is provided in `.env.example`.
 
 ### Fields
 
@@ -83,7 +83,7 @@ Create a `src/config.js` file or provide the values as environment variables whe
 - **HTTP_ENDPOINT** – URL of the GraphQL HTTP endpoint.
 - **WS_ENDPOINT** – GraphQL WebSocket endpoint for real-time updates. Typically the same host as `HTTP_ENDPOINT` using `wss://` and appending `?apiKey=YOUR_API_KEY`.
 
-When running in the browser without a bundler, copy `src/config.example.js` to `src/config.js` and fill in your actual values. The repository's `.gitignore` already excludes `src/config.js` so your secrets stay out of version control.
+When running in the browser without a bundler, copy `.env.example` to `.env` and fill in your actual values. The repository's `.gitignore` already excludes this file so your secrets stay out of version control.
 
 ## Tests
 

--- a/src/config.example.js
+++ b/src/config.example.js
@@ -1,8 +1,0 @@
-// Copy this file to config.js and replace the placeholder values with your actual configuration.
-window.APP_CONFIG = {
-  API_KEY: "YOUR_API_KEY",
-  AWS_PARAM: "YOUR_AWS_PARAM",
-  AWS_PARAM_URL: "https://your-domain.com/s/aws",
-  HTTP_ENDPOINT: "https://your-domain.com/api/v1/graphql",
-  WS_ENDPOINT: "wss://your-domain.com/api/v1/graphql?apiKey=YOUR_API_KEY",
-};

--- a/src/config.js
+++ b/src/config.js
@@ -1,11 +1,7 @@
-window.APP_CONFIG = {
-  API_KEY: "uXVeRpnkFYHhT8SQK6JXo",
-  AWS_PARAM: "5d26643c9bf758f00272ffed8558a0d9",
-  AWS_PARAM_URL: "https://learn.eduflowpro.com/s/aws",
-  HTTP_ENDPOINT: "https://eduflowpro.vitalstats.app/api/v1/graphql",
-  WS_ENDPOINT:
-    "wss://eduflowpro.vitalstats.app/api/v1/graphql?apiKey=uXVeRpnkFYHhT8SQK6JXo",
-};
+// Runtime configuration can be provided by populating `window.APP_CONFIG`
+// or via environment variables when bundling. `window.APP_CONFIG` is left
+// empty by default so secrets are not committed to the repository.
+window.APP_CONFIG = {};
 
 export const env = (typeof process !== "undefined" && process.env) || {};
 export const cfg = (typeof window !== "undefined" && window.APP_CONFIG) || {};
@@ -16,11 +12,11 @@ export const awsParamUrl = cfg.AWS_PARAM_URL || env.AWS_PARAM_URL || "";
 export const HTTP_ENDPOINT =
   cfg.HTTP_ENDPOINT ||
   env.HTTP_ENDPOINT ||
-  "https://eduflowpro.vitalstats.app/api/v1/graphql";
+  "";
 export const WS_ENDPOINT =
   cfg.WS_ENDPOINT ||
   env.WS_ENDPOINT ||
-  `wss://eduflowpro.vitalstats.app/api/v1/graphql?apiKey=${API_KEY}`;
+  "";
 
 if (typeof window !== "undefined") {
   window.awsParam = awsParam;


### PR DESCRIPTION
## Summary
- strip out credentials from `config.js`
- ignore `.env` and add example file
- document config updates in README
- remove unused config example

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find module 'globals')*

------
https://chatgpt.com/codex/tasks/task_b_684be34603ec8321bc8d7d74cda15ad0