### PR TITLE
Improve error handling for fetches

### DIFF
--- a/src/api/fetch.js
+++ b/src/api/fetch.js
@@ -1,13 +1,44 @@
 import { HTTP_ENDPOINT, API_KEY } from '../config.js';
 
-export function fetchGraphQL(query, variables = {}) {
-  return fetch(HTTP_ENDPOINT, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      "Api-Key": API_KEY,
-    },
-    body: JSON.stringify({ query, variables }),
-  }).then((r) => r.json());
+export async function fetchGraphQL(query, variables = {}) {
+  let response;
+  try {
+    response = await fetch(HTTP_ENDPOINT, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Api-Key": API_KEY,
+      },
+      body: JSON.stringify({ query, variables }),
+    });
+  } catch (err) {
+    throw new Error(`Network error: ${err.message}`);
+  }
+
+  let data;
+  try {
+    data = await response.json();
+  } catch (err) {
+    throw new Error("Invalid JSON in response");
+  }
+
+  if (!response.ok) {
+    const message = Array.isArray(data.errors)
+      ? data.errors.map((e) => e.message).join(", ")
+      : response.statusText;
+    const error = new Error(`Request failed with status ${response.status}: ${message}`);
+    error.response = data;
+    error.status = response.status;
+    throw error;
+  }
+
+  if (Array.isArray(data.errors) && data.errors.length > 0) {
+    const error = new Error(data.errors.map((e) => e.message).join(", "));
+    error.response = data;
+    error.status = response.status;
+    throw error;
+  }
+
+  return data;
 }
 

--- a/src/domEvents.js
+++ b/src/domEvents.js
@@ -45,14 +45,22 @@ function renderContacts(list, containerId) {
 }
 
 export function loadModalContacts() {
-  fetchGraphQL(GET_SUBSCRIBER_CONTACTS_FOR_MODAL).then((res) => {
-    const contacts = res?.data?.calcContacts || [];
-    renderContacts(contacts, "subscriberContacts");
-  });
-  fetchGraphQL(GET_ADMIN_CONTACTS_FOR_MODAL).then((res) => {
-    const contacts = res?.data?.calcContacts || [];
-    renderContacts(contacts, "adminContacts");
-  });
+  fetchGraphQL(GET_SUBSCRIBER_CONTACTS_FOR_MODAL)
+    .then((res) => {
+      const contacts = res?.data?.calcContacts || [];
+      renderContacts(contacts, "subscriberContacts");
+    })
+    .catch((err) => {
+      console.error("Failed to load subscriber contacts", err);
+    });
+  fetchGraphQL(GET_ADMIN_CONTACTS_FOR_MODAL)
+    .then((res) => {
+      const contacts = res?.data?.calcContacts || [];
+      renderContacts(contacts, "adminContacts");
+    })
+    .catch((err) => {
+      console.error("Failed to load admin contacts", err);
+    });
 }
 
 export function setupCreatePostModal() {

--- a/src/main.js
+++ b/src/main.js
@@ -29,23 +29,27 @@ function startApp(tagName, contactId, displayName) {
   }
 
   tribute.attach(document.getElementById("post-editor"));
-  fetchGraphQL(FETCH_CONTACTS_QUERY).then((res) => {
-    const contacts = res.data.calcContacts;
-    state.allContacts = contacts.map(c => c.Contact_ID);
-    tribute.collection[0].values = contacts.map((c) => ({
-      key: c.Display_Name || "Anonymous",
-      value: c.Contact_ID,
-      image: c.Profile_Image,
-    }));
-    const current = contacts.find((c) => c.Contact_ID === GLOBAL_AUTHOR_ID);
-    if (current) {
-      state.currentUser = {
-        display_name: current.Display_Name || "Anonymous",
-        profile_image: current.Profile_Image || DEFAULT_AVATAR,
-      };
-      updateCurrentUserUI(state);
-    }
-  });
+  fetchGraphQL(FETCH_CONTACTS_QUERY)
+    .then((res) => {
+      const contacts = res.data.calcContacts;
+      state.allContacts = contacts.map((c) => c.Contact_ID);
+      tribute.collection[0].values = contacts.map((c) => ({
+        key: c.Display_Name || "Anonymous",
+        value: c.Contact_ID,
+        image: c.Profile_Image,
+      }));
+      const current = contacts.find((c) => c.Contact_ID === GLOBAL_AUTHOR_ID);
+      if (current) {
+        state.currentUser = {
+          display_name: current.Display_Name || "Anonymous",
+          profile_image: current.Profile_Image || DEFAULT_AVATAR,
+        };
+        updateCurrentUserUI(state);
+      }
+    })
+    .catch((err) => {
+      console.error("Failed to fetch contacts", err);
+    });
 
   initPosts();
   initFilePond();
@@ -56,23 +60,27 @@ function startApp(tagName, contactId, displayName) {
   fetchGraphQL(GET_CONTACTS_BY_TAGS, {
     id: GLOBAL_AUTHOR_ID,
     name: contactTagForQuery,
-  }).then((res) => {
-    const result = res?.data?.calcContacts;
-    if (Array.isArray(result) && result.length > 0) {
-      setContactIncludedInTag(true);
-      connect();
-      connectNotification();
-    } else {
-      const el = document.getElementById("forum-root");
-      document.getElementById("skeleton-loader")?.remove();
-      el.replaceChildren(
-        Object.assign(document.createElement("h2"), {
-          className: "text-center text-gray-500",
-          textContent: "No posts found.",
-        })
-      );
-    }
-  });
+  })
+    .then((res) => {
+      const result = res?.data?.calcContacts;
+      if (Array.isArray(result) && result.length > 0) {
+        setContactIncludedInTag(true);
+        connect();
+        connectNotification();
+      } else {
+        const el = document.getElementById("forum-root");
+        document.getElementById("skeleton-loader")?.remove();
+        el.replaceChildren(
+          Object.assign(document.createElement("h2"), {
+            className: "text-center text-gray-500",
+            textContent: "No posts found.",
+          })
+        );
+      }
+    })
+    .catch((err) => {
+      console.error("Failed to check contact tags", err);
+    });
 }
 
 function loadSelectedUserForum(tagName, contactId, displayName, profileImage) {


### PR DESCRIPTION
## Summary
- check HTTP and GraphQL errors in `fetchGraphQL`
- log failures when loading contacts
- log failures when starting the app

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find module 'globals')*

------
https://chatgpt.com/codex/tasks/task_b_684bf1a8bc408321a5480ab8edbc18e3