### PR TITLE
Load post details in modal

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -66,9 +66,7 @@
           </svg>
         </div>
       </div>
-      <!-- Dialog Body -->
-      <div class="flex flex-col gap-1">
-        <div>Content</div>
+      <div id="modalForumRoot" class="flex flex-col gap-1"></div>
       </div>
       <!-- Dialog Footer -->
 
@@ -972,7 +970,7 @@
     </svg>
     <div class="p3">Like</div>
   </div>
-  <div @click="modalForPostOpen=true">OpenPostModal</div>
+  <div class="openPostModal cursor-pointer" data-id="{{:id}}" @click="modalForPostOpen=true">OpenPostModal</div>
    {{if !commentsDisabled && forumStatus !== 'Scheduled'}}
   <div class="flex btn-comment flex-1 items-center justify-center gap-2 cursor-pointer" data-uid="{{:uid}}">
     <svg width="17" height="16" viewBox="0 0 17 16" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/src/features/posts/index.js
+++ b/src/features/posts/index.js
@@ -3,6 +3,7 @@ import { initReactionHandlers } from './reactions.js';
 import { initModerationHandlers } from './moderation.js';
 import { initFilterHandlers, applyFilterAndRender } from './filters.js';
 import { initPreviewHandlers } from './preview.js';
+import { initPostModalHandlers } from './postModal.js';
 
 export function initPosts() {
   initCommentHandlers();
@@ -10,6 +11,7 @@ export function initPosts() {
   initModerationHandlers();
   initFilterHandlers();
   initPreviewHandlers();
+  initPostModalHandlers();
 }
 
 export { applyFilterAndRender };

--- a/src/features/posts/postModal.js
+++ b/src/features/posts/postModal.js
@@ -1,0 +1,77 @@
+import { fetchGraphQL } from "../../api/fetch.js";
+import { GET_SINGLE_POST_SUBSCRIPTION } from "../../api/queries.js";
+import { buildTree } from "../../ui/render.js";
+import { tmpl } from "../../ui/render.js";
+import { setupPlyr } from "../../utils/plyr.js";
+
+function normalize(node, list) {
+  const {
+    Author_ID,
+    Formatted_Json,
+    Date_Added,
+    Published_Date,
+    Disable_New_Comments,
+    Featured_Forum,
+    File_Content,
+    File_Type,
+    ID,
+    Copy,
+    Forum_Status,
+    Unique_ID,
+    Depth,
+    Forum_Type,
+    Parent_Forum_ID,
+    Author,
+    Bookmarking_Contacts_Data,
+    Forum_Reactors_Data,
+    ForumPosts,
+  } = node;
+  list.push({
+    author_id: Author_ID,
+    formatted_json: Formatted_Json,
+    created_at: Date_Added,
+    published_date: Published_Date,
+    disable_new_comments: Disable_New_Comments,
+    featured_forum: Featured_Forum,
+    file_content: File_Content,
+    file_type: File_Type,
+    id: ID,
+    copy: Copy,
+    forum_status: Forum_Status,
+    unique_id: Unique_ID,
+    depth: Depth,
+    forum_type: Forum_Type,
+    parent_forum_id: Parent_Forum_ID,
+    Author,
+    Bookmarking_Contacts_Data,
+    Forum_Reactors_Data,
+  });
+  if (Array.isArray(ForumPosts)) {
+    ForumPosts.forEach((child) => normalize(child, list));
+  }
+}
+
+export function initPostModalHandlers() {
+  $(document).on("click", ".openPostModal", async function () {
+    const postId = $(this).data("id");
+    if (!postId) return;
+    const container = document.getElementById("modalForumRoot");
+    if (container) {
+      container.innerHTML = "";
+    }
+    try {
+      const res = await fetchGraphQL(GET_SINGLE_POST_SUBSCRIPTION, { id: postId });
+      const data = res?.data?.subscribeToForumPost;
+      if (!data) return;
+      const list = [];
+      normalize(data, list);
+      const tree = buildTree([], list);
+      if (container) {
+        container.innerHTML = tmpl.render(tree);
+        requestAnimationFrame(setupPlyr);
+      }
+    } catch (err) {
+      console.error("Failed to load post", err);
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- wire up modal to show full post thread
- allow clicking a post action to open the modal

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find module 'globals')*

------
https://chatgpt.com/codex/tasks/task_b_6853b0db36c083218ba95ae1787a3636