### PR TITLE
Add modal skeleton loader and dynamic author name

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -970,7 +970,7 @@
     </svg>
     <div class="p3">Like</div>
   </div>
-  <div class="openPostModal cursor-pointer" data-id="{{:id}}" @click="modalForPostOpen=true">OpenPostModal</div>
+  <div class="openPostModal cursor-pointer" data-id="{{:id}}" data-author="{{:authorName}}" @click="modalForPostOpen=true">OpenPostModal</div>
    {{if !commentsDisabled && forumStatus !== 'Scheduled'}}
   <div class="flex btn-comment flex-1 items-center justify-center gap-2 cursor-pointer" data-uid="{{:uid}}">
     <svg width="17" height="16" viewBox="0 0 17 16" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/src/features/posts/postModal.js
+++ b/src/features/posts/postModal.js
@@ -4,6 +4,18 @@ import { tmpl } from "../../ui/render.js";
 import { setupPlyr } from "../../utils/plyr.js";
 import { PROTOCOL, WS_ENDPOINT, KEEPALIVE_MS } from "../../config.js";
 
+const MODAL_SKELETON = `
+  <div id="modal-skeleton-loader" class="p-4">
+    <div class="skeleton-item flex gap-4 mb-4">
+      <div class="skeleton-avatar"></div>
+      <div class="flex-1 flex flex-col gap-2">
+        <div class="skeleton-line short"></div>
+        <div class="skeleton-line"></div>
+        <div class="skeleton-line medium"></div>
+      </div>
+    </div>
+  </div>`;
+
 function normalize(node, list) {
   const {
     Author_ID,
@@ -68,10 +80,16 @@ function closeModalSocket() {
 export function initPostModalHandlers() {
   $(document).on("click", ".openPostModal", function () {
     const postId = $(this).data("id");
+    const author = $(this).data("author");
     if (!postId) return;
     const container = document.getElementById("modalForumRoot");
     if (container) {
-      container.innerHTML = "";
+      container.innerHTML = MODAL_SKELETON;
+    }
+
+    const titleEl = document.getElementById("defaultModalTitle");
+    if (titleEl) {
+      titleEl.textContent = author || "";
     }
 
     closeModalSocket();


### PR DESCRIPTION
## Summary
- show skeleton loader while fetching modal data
- update modal header with clicked post author's name

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find module 'globals')*

------
https://chatgpt.com/codex/tasks/task_b_6853b4b104b8832189e7eec860ab96b2