### PR TITLE
Update comment display in modal

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -847,7 +847,7 @@
                    {{/if}}
                  </div>
                </div>
-               {{if canDelete}}
+               {{if canDelete && (!~inModal || depth > 0)}}
                   <div x-data="{ threeDotsForAdmin: false, openedWithKeyboard: false }" class="relative w-fit" x-on:keydown.esc.window="threeDotsForAdmin = false, openedWithKeyboard = false">
              <!-- Toggle Button -->
              <div x-on:click="threeDotsForAdmin = ! threeDotsForAdmin" aria-haspopup="true" x-on:keydown.space.prevent="openedWithKeyboard = true" x-on:keydown.enter.prevent="openedWithKeyboard = true" class="cursor-pointer" x-on:keydown.down.prevent="openedWithKeyboard = true">
@@ -970,7 +970,9 @@
     </svg>
     <div class="p3">Like</div>
   </div>
+  {{if !~inModal}}
   <div class="openPostModal cursor-pointer" data-id="{{:id}}" data-author="{{:authorName}}" @click="modalForPostOpen=true">OpenPostModal</div>
+  {{/if}}
    {{if !commentsDisabled && forumStatus !== 'Scheduled'}}
   <div class="flex btn-comment flex-1 items-center justify-center gap-2 cursor-pointer" data-uid="{{:uid}}">
     <svg width="17" height="16" viewBox="0 0 17 16" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -989,14 +991,14 @@
   {{/if}}
 </div>
        {{/if}}
-               {{if depth === 0 && forumStatus !== 'Scheduled'}}
+               {{if depth === 0 && forumStatus !== 'Scheduled' && !~inModal}}
                <div class="ribbon w-full  py-2 bg-[#e9ebee] text-center cursor-pointer text-sm hover:bg-[#007bff] hover:text-white" data-uid="{{:uid}}">
          {{:~totalComments(children)}} {{:~totalComments(children) === 1 ? 'Comment' : 'Comments'}}
        </div>
 
-               {{else depth === 1}}
+               {{else depth === 1 && isCollapsed}}
                <div class="ribbon w-full  py-2 bg-[#e9ebee] text-center cursor-pointer text-sm hover:bg-[#007bff] hover:text-white" data-uid="{{:uid}}">
-                   {{:children.length}} {{:children.length === 1 ? 'Reply' : 'Replies'}}
+                   See {{:children.length}} more {{:children.length === 1 ? 'reply' : 'replies'}}
                </div>
                {{/if}}
                {{if children.length && !isCollapsed}}

--- a/src/features/posts/comments.js
+++ b/src/features/posts/comments.js
@@ -61,7 +61,12 @@ export function initCommentHandlers() {
   </div>
 
   `);
-    container.append($form);
+    const ribbon = container.find('.ribbon').first();
+    if (ribbon.length) {
+      $form.insertBefore(ribbon);
+    } else {
+      container.append($form);
+    }
     const inserted = container.find(".comment-form");
     if (inserted.length) {
       const editorEl = inserted.find(".editor")[0];

--- a/src/features/posts/filters.js
+++ b/src/features/posts/filters.js
@@ -76,7 +76,7 @@ export function applyFilterAndRender() {
       }
     });
 
-    $container.html(tmpl.render(items));
+    $container.html(tmpl.render(items, { inModal: false }));
 
     for (const uid in frames) {
       const $item = $container.find(`[data-uid="${uid}"]`);

--- a/src/features/posts/postModal.js
+++ b/src/features/posts/postModal.js
@@ -133,9 +133,27 @@ export function initPostModalHandlers() {
         const list = [];
         normalize(data, list);
         const tree = buildTree([], list);
+        // open comments and collapse replies by default
+        function adjustCollapse(nodes) {
+          nodes.forEach((n) => {
+            if (n.depth === 1) {
+              n.isCollapsed = false;
+            } else if (n.depth >= 2) {
+              n.isCollapsed = true;
+            }
+            if (Array.isArray(n.children)) adjustCollapse(n.children);
+          });
+        }
+        adjustCollapse(tree);
+
         if (container) {
-          container.innerHTML = tmpl.render(tree);
-          requestAnimationFrame(setupPlyr);
+          container.innerHTML = tmpl.render(tree, { inModal: true });
+          requestAnimationFrame(() => {
+            setupPlyr();
+            // automatically show comment form for the post
+            const btn = container.querySelector('.item[data-depth="0"] .btn-comment');
+            btn && btn.click();
+          });
         }
       } else if (msg.type === "GQL_ERROR") {
         console.error("Subscription error", msg.payload);


### PR DESCRIPTION
## Summary
- keep home page simple with posts only
- open comments automatically in modal
- insert comment form before ribbon
- customize ribbon text for replies and hide for posts in modal

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find module 'globals')*

------
https://chatgpt.com/codex/tasks/task_b_6853b853fca88321a00c7da3d896fff0