### PR TITLE
Fix comments visibility

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -991,7 +991,7 @@
   {{/if}}
 </div>
        {{/if}}
-               {{if depth === 0 && forumStatus !== 'Scheduled' && !~inModal}}
+               {{if depth === 0 && forumStatus !== 'Scheduled' && ~inModal}}
                <div class="ribbon w-full  py-2 bg-[#e9ebee] text-center cursor-pointer text-sm hover:bg-[#007bff] hover:text-white" data-uid="{{:uid}}">
          {{:~totalComments(children)}} {{:~totalComments(children) === 1 ? 'Comment' : 'Comments'}}
        </div>
@@ -999,6 +999,10 @@
                {{else depth === 1 && isCollapsed}}
                <div class="ribbon w-full  py-2 bg-[#e9ebee] text-center cursor-pointer text-sm hover:bg-[#007bff] hover:text-white" data-uid="{{:uid}}">
                    See {{:children.length}} more {{:children.length === 1 ? 'reply' : 'replies'}}
+               </div>
+               {{else depth === 1}}
+               <div class="ribbon w-full  py-2 bg-[#e9ebee] text-center cursor-pointer text-sm hover:bg-[#007bff] hover:text-white" data-uid="{{:uid}}">
+                   Hide replies
                </div>
                {{/if}}
                {{if children.length && !isCollapsed}}

--- a/src/features/posts/filters.js
+++ b/src/features/posts/filters.js
@@ -11,7 +11,7 @@ export function applyFilterAndRender() {
     skeleton?.classList.add('hidden');
   }
   requestAnimationFrame(setupPlyr);
-  let items = state.postsStore;
+  let items = state.postsStore.filter((p) => p.depth === 0);
   switch (state.currentFilter) {
     case "Featured":
       items = items.filter((p) => p.isFeatured);


### PR DESCRIPTION
## Summary
- show only posts on the home feed
- move comment ribbon into modal view
- allow hiding replies inside the modal

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find module 'globals')*

------
https://chatgpt.com/codex/tasks/task_b_6853ba3c7f7c83218db75d7c7d7b2530