### PR TITLE
Update post subscription and modal behavior

### DIFF
--- a/src/api/queries.js
+++ b/src/api/queries.js
@@ -99,10 +99,11 @@ export const SUBSCRIBE_FORUM_POSTS = `
               forum_status: "Published - Not flagged"
             }
           }
-          { orWhere: { forum_status: "Scheduled" } }
+        { orWhere: { forum_status: "Scheduled" } }
         ]
       }
         { andWhere: { forum_tag: $forum_tag } }
+        { andWhere: { forum_type: "Post" } }
       ]
       orderBy: [{ path: ["published_date"], type: desc }]
     ) {

--- a/src/features/posts/postModal.js
+++ b/src/features/posts/postModal.js
@@ -150,18 +150,14 @@ export function initPostModalHandlers() {
         const list = [];
         normalize(data, list);
         modalTree = buildTree([], list);
-        // open comments and collapse replies by default
-        function adjustCollapse(nodes) {
+        // open comments and replies by default
+        function expandAll(nodes) {
           nodes.forEach((n) => {
-            if (n.depth === 1) {
-              n.isCollapsed = false;
-            } else if (n.depth >= 2) {
-              n.isCollapsed = true;
-            }
-            if (Array.isArray(n.children)) adjustCollapse(n.children);
+            n.isCollapsed = false;
+            if (Array.isArray(n.children)) expandAll(n.children);
           });
         }
-        adjustCollapse(modalTree);
+        expandAll(modalTree);
 
         if (container) {
           renderModal();


### PR DESCRIPTION
## Summary
- filter websocket post subscription to only retrieve posts
- keep all comments and replies expanded in the post modal

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find module 'globals')*

------
https://chatgpt.com/codex/tasks/task_b_6853bf2299c88321972ae6144a679a01