### PR TITLE
Fix comment form when used inside modal

### DIFF
--- a/src/features/posts/postModal.js
+++ b/src/features/posts/postModal.js
@@ -21,6 +21,10 @@ export function rerenderModal() {
   renderModal();
 }
 
+export function getModalTree() {
+  return modalTree;
+}
+
 const MODAL_SKELETON = `
   <div id="modal-skeleton-loader" class="p-4">
     <div class="skeleton-item flex gap-4 mb-4">


### PR DESCRIPTION
## Summary
- use modal tree when comment or ribbon is triggered inside modal
- export helper to access modal data

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find module 'globals')*

------
https://chatgpt.com/codex/tasks/task_b_6853c09805c0832181c9a4fb8dafefc8