### PR TITLE
Fix parent forum id when posting from modal

### DIFF
--- a/src/features/posts/actions.js
+++ b/src/features/posts/actions.js
@@ -20,6 +20,7 @@ import { showToast } from "../../ui/toast.js";
 import { ensureCurrentUser } from "./user.js";
 import { processContent } from "./content.js";
 import { sendNotificationsAfterPost } from "./notifications.js";
+import { getModalTree } from "./postModal.js";
 
 export async function createForumToSubmit(
   depthOfForum,
@@ -51,7 +52,9 @@ export async function createForumToSubmit(
 
   let parentForumId;
   if (forumType !== "Post" && uidParam) {
-    const node = findNode(state.postsStore, uidParam);
+    const inModal = $(this).closest("#modalForumRoot").length > 0;
+    const source = inModal ? getModalTree() : state.postsStore;
+    const node = findNode(source, uidParam);
     parentForumId = node ? node.id : null;
   }
   let publishedDatePayload = Date.now();


### PR DESCRIPTION
## Summary
- ensure comments/replies created from the modal correctly look up their parent post

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find module 'globals')*

------
https://chatgpt.com/codex/tasks/task_b_6853c72d396083219eff95ba315a2dbb