### PR TITLE
Fix parentForumId lookup for replies

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -818,6 +818,7 @@
              
                class="item rounded bg-white flex flex-col gap-[14px] p-4 relative {{if depth === 1}} commentContainer {{/if}}"
                data-uid="{{:uid}}"
+               data-id="{{:id}}"
                data-depth="{{:depth}}"
                data-forumStatus="{{:forumStatus}}"
               

--- a/src/features/posts/actions.js
+++ b/src/features/posts/actions.js
@@ -55,7 +55,12 @@ export async function createForumToSubmit(
     const inModal = $(this).closest("#modalForumRoot").length > 0;
     const source = inModal ? getModalTree() : state.postsStore;
     const node = findNode(source, uidParam);
-    parentForumId = node ? node.id : null;
+    if (node) {
+      parentForumId = node.id;
+    } else {
+      const container = $(this).closest('.item');
+      parentForumId = Number(container.data('id')) || null;
+    }
   }
   let publishedDatePayload = Date.now();
   let forumStatusForPayload = "Published - Not flagged";


### PR DESCRIPTION
## Summary
- add `data-id` attribute to forum item template
- fallback to DOM `data-id` when locating parent id for new comments

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find module 'globals')*

------
https://chatgpt.com/codex/tasks/task_b_6853d90a2ae083219531ee7f4c1eaf96