### PR TITLE
Remove ribbon and keep replies collapsed

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -993,20 +993,7 @@
   {{/if}}
 </div>
        {{/if}}
-               {{if depth === 0 && forumStatus !== 'Scheduled' && ~inModal}}
-               <div class="ribbon w-full  py-2 bg-[#e9ebee] text-center cursor-pointer text-sm hover:bg-[#007bff] hover:text-white" data-uid="{{:uid}}">
-         {{:~totalComments(children)}} {{:~totalComments(children) === 1 ? 'Comment' : 'Comments'}}
-       </div>
-
-               {{else depth === 1 && isCollapsed}}
-               <div class="ribbon w-full  py-2 bg-[#e9ebee] text-center cursor-pointer text-sm hover:bg-[#007bff] hover:text-white" data-uid="{{:uid}}">
-                   See {{:children.length}} more {{:children.length === 1 ? 'reply' : 'replies'}}
-               </div>
-               {{else depth === 1}}
-               <div class="ribbon w-full  py-2 bg-[#e9ebee] text-center cursor-pointer text-sm hover:bg-[#007bff] hover:text-white" data-uid="{{:uid}}">
-                   Hide replies
-               </div>
-               {{/if}}
+              {{!-- Ribbon removed; replies remain collapsed by default --}}
                {{if children.length && !isCollapsed}}
                  <div data-reply="{{:uid}}" class="children visible my-4 {{:depth < 2 ? 'pl-8 ml-[12px] border-l border-2-[#e9ebee]' : ''}}">
                    {{for children}}

--- a/src/features/posts/comments.js
+++ b/src/features/posts/comments.js
@@ -69,12 +69,7 @@ export function initCommentHandlers() {
   </div>
 
   `);
-    const ribbon = container.find('.ribbon').first();
-    if (ribbon.length) {
-      $form.insertBefore(ribbon);
-    } else {
-      container.append($form);
-    }
+    container.append($form);
     const inserted = container.find(".comment-form");
     if (inserted.length) {
       const editorEl = inserted.find(".editor")[0];
@@ -98,20 +93,5 @@ export function initCommentHandlers() {
     }
   });
 
-  $(document).on("click", ".ribbon", function () {
-    const uid = $(this).attr("data-uid");
-    const inModal = $(this).closest("#modalForumRoot").length > 0;
-    const source = inModal ? getModalTree() : state.postsStore;
-    const node = findNode(source, uid);
-    if (node) {
-      node.isCollapsed = !node.isCollapsed;
-      if (!inModal) {
-        state.collapsedState[node.uid] = node.isCollapsed;
-      }
-      applyFilterAndRender();
-      if (inModal) {
-        rerenderModal();
-      }
-    }
-  });
+  // Ribbon removal: replies stay hidden by default
 }

--- a/src/ui/render.js
+++ b/src/ui/render.js
@@ -25,12 +25,12 @@ export function buildTree(existingPosts, rawItems) {
     }
   });
 
-  function cloneState(uid) {
+  function cloneState(uid, defaultState = true) {
     if (state.collapsedState.hasOwnProperty(uid)) {
       return { isCollapsed: state.collapsedState[uid] };
     }
-    state.collapsedState[uid] = true;
-    return { isCollapsed: true };
+    state.collapsedState[uid] = defaultState;
+    return { isCollapsed: defaultState };
   }
 
   function convert(rawArr, depth = 0, inheritedDisable = false) {
@@ -38,7 +38,8 @@ export function buildTree(existingPosts, rawItems) {
     for (const raw of rawArr) {
       const nodeDisable = inheritedDisable || raw.disable_new_comments === true;
       const node = mapItem(raw, depth, nodeDisable);
-      Object.assign(node, cloneState(node.uid));
+      const defaultCollapse = depth === 0 ? false : true;
+      Object.assign(node, cloneState(node.uid, defaultCollapse));
       node.children = [];
       list.push(node);
       const nextDepth = depth === 0 ? 1 : 2;


### PR DESCRIPTION
## Summary
- remove the ribbon markup from `tmpl-item`
- stop injecting comment forms before the ribbon and drop the click handler
- default posts expanded but keep replies collapsed

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6853e3fafc688321a569bb400e12634b