### PR TITLE
Add replies ribbon and keep modal replies collapsed

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -996,7 +996,16 @@
   {{/if}}
 </div>
        {{/if}}
-              {{!-- Ribbon removed; replies remain collapsed by default --}}
+              {{!-- Toggle replies ribbon below comment --}}
+               {{if depth === 1 && children.length}}
+                 <div class="reply-ribbon mt-2 cursor-pointer toggle-replies bg-[var(--grey-200)] rounded p-2 text-center" data-uid="{{:uid}}">
+                   {{if isCollapsed}}
+                     View {{:children.length}} replies
+                   {{else}}
+                     Hide replies
+                   {{/if}}
+                 </div>
+               {{/if}}
                {{if children.length && !isCollapsed}}
                  <div data-reply="{{:uid}}" class="children visible my-4 {{:depth < 2 ? 'pl-8 ml-[12px] border-l border-2-[#e9ebee]' : ''}}">
                    {{for children}}

--- a/src/features/posts/postModal.js
+++ b/src/features/posts/postModal.js
@@ -156,14 +156,7 @@ export function initPostModalHandlers() {
         const list = [];
         normalize(data, list);
         modalTree = buildTree([], list);
-        // open comments and replies by default
-        function expandAll(nodes) {
-          nodes.forEach((n) => {
-            n.isCollapsed = false;
-            if (Array.isArray(n.children)) expandAll(n.children);
-          });
-        }
-        expandAll(modalTree);
+        // replies remain collapsed; only main comment form opens initially
 
         if (container) {
           renderModal(firstRender);


### PR DESCRIPTION
## Summary
- add a ribbon to toggle replies below comments
- collapse replies by default in the post modal

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6853e892d51883219aaa494f3c71f6cf