### PR TITLE
Improve collapsed reply ribbon style

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -816,7 +816,7 @@
            {{if (forumType === 'Post' || forumType === 'Reply' || forumType === 'Comment') && (forumStatus === 'Published - Not flagged' || (forumStatus === 'Scheduled' && isAdmin))}}
              <div
              
-               class="item rounded bg-white flex flex-col gap-[14px] p-4 relative {{if depth === 1}}commentContainer commentContainer_{{:uid}} {{/if}}"
+              class="item rounded bg-white flex flex-col gap-[14px] p-4 relative {{if depth === 1}}commentContainer commentContainer_{{:uid}} {{/if}} {{if depth === 1 && children.length}}has-replies{{/if}} {{if depth === 1 && isCollapsed}}is-collapsed{{/if}}"
                data-uid="{{:uid}}"
                data-id="{{:id}}"
                data-depth="{{:depth}}"

--- a/public/styles/style.css
+++ b/public/styles/style.css
@@ -468,4 +468,22 @@ button:not(.file-preview button):hover {
   padding: 8px !important;
 }
 
+/* Collapsed comment styling with ribbon */
+.commentContainer.has-replies.is-collapsed {
+  margin-left: 12px;
+  padding-left: 1.5rem;
+  border-left: 2px solid #e9ebee;
+}
+
+.reply-ribbon {
+  padding-left: 1.5rem;
+  margin-left: 12px;
+  color: var(--color-primary);
+  font-size: 0.875rem;
+}
+
+.commentContainer.has-replies.is-collapsed .reply-ribbon {
+  padding-left: 0;
+}
+
 /* Dropdown UI */


### PR DESCRIPTION
## Summary
- add state classes when rendering comments with replies
- style the comment ribbon for collapsed threads

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find module 'globals')*

------
https://chatgpt.com/codex/tasks/task_b_6853ec9b100c83218850b423b03e0e87