### PR TITLE
Open posts from notifications

### DIFF
--- a/src/features/posts/postModal.js
+++ b/src/features/posts/postModal.js
@@ -95,23 +95,31 @@ function closeModalSocket() {
   modalSocket = null;
 }
 
-export function initPostModalHandlers() {
-  $(document).on("click", ".openPostModal", function () {
-    const postId = $(this).data("id");
-    const author = $(this).data("author");
-    if (!postId) return;
-    const container = document.getElementById("modalForumRoot");
-    if (container) {
-      container.innerHTML = MODAL_SKELETON;
-    }
+export function openPostModalById(postId, author = "") {
+  if (!postId) return;
 
-    const titleEl = document.getElementById("defaultModalTitle");
-    if (titleEl) {
-      titleEl.textContent = author || "";
+  // ensure the modal is displayed (Alpine data)
+  try {
+    const body = document.querySelector("body");
+    if (body && body.__x && body.__x.$data) {
+      body.__x.$data.modalForPostOpen = true;
     }
+  } catch {
+    // ignore if Alpine isn't available
+  }
 
-    closeModalSocket();
-    modalSocket = new WebSocket(WS_ENDPOINT, PROTOCOL);
+  const container = document.getElementById("modalForumRoot");
+  if (container) {
+    container.innerHTML = MODAL_SKELETON;
+  }
+
+  const titleEl = document.getElementById("defaultModalTitle");
+  if (titleEl) {
+    titleEl.textContent = author || "";
+  }
+
+  closeModalSocket();
+  modalSocket = new WebSocket(WS_ENDPOINT, PROTOCOL);
 
     modalSocket.addEventListener("open", () => {
       modalSocket.send(JSON.stringify({ type: "CONNECTION_INIT" }));
@@ -167,11 +175,18 @@ export function initPostModalHandlers() {
       closeModalSocket();
     });
 
-    modalSocket.addEventListener("close", () => {
-      clearInterval(keepAliveTimer);
-      keepAliveTimer = null;
-      modalSocket = null;
-    });
+  modalSocket.addEventListener("close", () => {
+    clearInterval(keepAliveTimer);
+    keepAliveTimer = null;
+    modalSocket = null;
+  });
+}
+
+export function initPostModalHandlers() {
+  $(document).on("click", ".openPostModal", function () {
+    const postId = $(this).data("id");
+    const author = $(this).data("author");
+    openPostModalById(postId, author);
   });
 
   document.addEventListener("click", (e) => {

--- a/src/notifications.js
+++ b/src/notifications.js
@@ -9,6 +9,7 @@ import {
 } from "./config.js";
 import { GET_NOTIFICATIONS } from "./api/queries.js";
 import { fetchGraphQL } from "./api/fetch.js";
+import { openPostModalById } from "./features/posts/postModal.js";
 
 const notificationTemplate = $.templates("#notificationTemplate");
 
@@ -158,6 +159,14 @@ export function connectNotification() {
 
 export function initNotificationEvents() {
   document.addEventListener("click", async (e) => {
+    const notifEl = e.target.closest(".notification");
+    if (notifEl) {
+      const forumId = notifEl.getAttribute("data-parentforumid");
+      if (forumId) {
+        openPostModalById(forumId);
+      }
+    }
+
     const markAll = e.target.id === "markAllNotificationAsRead";
 
     let ids = [];


### PR DESCRIPTION
## Summary
- export `openPostModalById` in `postModal.js`
- use `openPostModalById` when clicking posts
- open the post modal when a notification is clicked

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find module 'globals')*

------
https://chatgpt.com/codex/tasks/task_b_6853fcdc8f408321bc8afe87f38b13f4