### PR TITLE
Fix modal visibility when clicking notifications

### DIFF
--- a/src/notifications.js
+++ b/src/notifications.js
@@ -163,6 +163,14 @@ export function initNotificationEvents() {
     if (notifEl) {
       const forumId = notifEl.getAttribute("data-parentforumid");
       if (forumId) {
+        try {
+          const body = document.querySelector("body");
+          if (body && body.__x && body.__x.$data) {
+            body.__x.$data.showNotifications = false;
+          }
+        } catch {
+          // ignore if Alpine isn't available
+        }
         openPostModalById(forumId);
       }
     }


### PR DESCRIPTION
## Summary
- close the notification dropdown before opening the post modal

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6853feee63588321a535285da224aace