### PR TITLE
Separate comment template

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -802,7 +802,7 @@
     </div>
   </div>
 
-  <script id="tmpl-item" type="text/x-jsrender">
+  <script id="tmpl-post" type="text/x-jsrender">
            {{if (forumType === 'Post' || forumType === 'Reply' || forumType === 'Comment') && (forumStatus === 'Published - Not flagged' || (forumStatus === 'Scheduled' && isAdmin))}}
              <div
              
@@ -1027,7 +1027,7 @@
                {{if children.length && !isCollapsed}}
                  <div data-reply="{{:uid}}" class="children visible my-4 {{:depth < 2 ? 'pl-6 ml-[12px] border-l border-2-[#e9ebee]' : ''}}">
                    {{for children}}
-                     {{include tmpl="#tmpl-item"/}}
+                     {{include tmpl="#tmpl-comment"/}}
                    {{/for}}
                  </div>
                {{/if}}
@@ -1035,6 +1035,239 @@
              {{/if}}
     </script>
 
+
+  <script id="tmpl-comment" type="text/x-jsrender">
+           {{if (forumType === 'Reply' || forumType === 'Comment') && (forumStatus === 'Published - Not flagged' || (forumStatus === 'Scheduled' && isAdmin))}}
+             <div
+             
+              class="item  {{:depth >0 ? 'rounded-[0_4px_4px_4px] p-[0_16px] mb-3' : 'rounded p-4'}} bg-white flex flex-col gap-[14px]  relative {{if depth === 1}}commentContainer commentContainer_{{:uid}} {{/if}} {{if depth === 1 && children.length}}has-replies{{/if}} {{if depth === 1 && isCollapsed}}is-collapsed{{/if}}"
+               data-uid="{{:uid}}"
+               data-id="{{:id}}"
+               data-depth="{{:depth}}"
+               data-forumStatus="{{:forumStatus}}"
+              
+               >
+               <div class="flex items-start justify-between">
+               <div class="author flex items-center mb-2">
+                 <img class="avatar w-[40px] h-[40px] bg-[#ccc] rounded-full mr-[12px]"
+                     src="{{:authorImage}}"
+                     alt="{{:authorName}}"
+                     onerror="this.onerror=null;this.src='https://files.ontraport.com/media/b0456fe87439430680b173369cc54cea.php03bzcx?Expires=4895186056&Signature=fw-mkSjms67rj5eIsiDF9QfHb4EAe29jfz~yn3XT0--8jLdK4OGkxWBZR9YHSh26ZAp5EHj~6g5CUUncgjztHHKU9c9ymvZYfSbPO9JGht~ZJnr2Gwmp6vsvIpYvE1pEywTeoigeyClFm1dHrS7VakQk9uYac4Sw0suU4MpRGYQPFB6w3HUw-eO5TvaOLabtuSlgdyGRie6Ve0R7kzU76uXDvlhhWGMZ7alNCTdS7txSgUOT8oL9pJP832UsasK4~M~Na0ku1oY-8a7GcvvVv6j7yE0V0COB9OP0FbC8z7eSdZ8r7avFK~f9Wl0SEfS6MkPQR2YwWjr55bbJJhZnZA__&Key-Pair-Id=APKAJVAAMVW6XQYWSTNA';">
+                 <div class="info flex items-start gap-2">
+                  <div class="flex flex-col items-start">
+                     <span class="name font-bold">{{:authorName}}</span>
+                     {{if forumStatus==='Scheduled'}}
+                <div class="flex items-center gap-1">
+                  <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
+                 <path d="M9 20H6C4.93913 20 3.92172 19.5786 3.17157 18.8284C2.42143 18.0783 2 17.0609 2 16V7C2 5.93913 2.42143 4.92172 3.17157 4.17157C3.92172 3.42143 4.93913 3 6 3H17C18.0609 3 19.0783 3.42143 19.8284 4.17157C20.5786 4.92172 21 5.93913 21 7V10M8 2V4M15 2V4M2 8H21M18.5 15.643L17 17.143" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                 <path d="M17 22C19.7614 22 22 19.7614 22 17C22 14.2386 19.7614 12 17 12C14.2386 12 12 14.2386 12 17C12 19.7614 14.2386 22 17 22Z" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+               </svg>
+                   <div class="text-sm text-[#65676b]">{{:~formatDate(sheduledDate)}}</div>
+                </div>
+                   {{else}}
+                   <span class="timestamp text-sm text-[#65676b]">{{:timeAgo}}</span>
+                   {{/if}}
+                  </div>
+                   {{if isFeatured}}
+                   <i class="fa-solid fa-star text-yellow-500 ml-2" title="Featured"></i>
+                   {{/if}}
+                 </div>
+                  
+               </div>
+               {{if ~inModal && depth === 0}}
+                 <div x-on:click="modalForPostOpen = false" class="group flex cursor-pointer items-center justify-start gap-2 rounded-[34px] bg-zinc-100 p-2 transition-all hover:bg-[var(--color-primary-shade)]">
+          <svg width="28" height="28" viewBox="0 0 28 28" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path d="M18.8535 18.146C18.8999 18.1925 18.9368 18.2476 18.9619 18.3083C18.9871 18.369 19 18.4341 19 18.4997C19 18.5654 18.9871 18.6305 18.9619 18.6912C18.9368 18.7519 18.8999 18.807 18.8535 18.8535C18.807 18.8999 18.7519 18.9368 18.6912 18.9619C18.6305 18.9871 18.5654 19 18.4997 19C18.4341 19 18.369 18.9871 18.3083 18.9619C18.2476 18.9368 18.1925 18.8999 18.146 18.8535L14 14.7068L9.85398 18.8535C9.76017 18.9473 9.63292 19 9.50025 19C9.36758 19 9.24033 18.9473 9.14652 18.8535C9.0527 18.7597 9 18.6324 9 18.4997C9 18.3671 9.0527 18.2398 9.14652 18.146L13.2932 14L9.14652 9.85398C9.0527 9.76017 9 9.63292 9 9.50025C9 9.36758 9.0527 9.24033 9.14652 9.14652C9.24033 9.0527 9.36758 9 9.50025 9C9.63292 9 9.76017 9.0527 9.85398 9.14652L14 13.2932L18.146 9.14652C18.2398 9.0527 18.3671 9 18.4997 9C18.6324 9 18.7597 9.0527 18.8535 9.14652C18.9473 9.24033 19 9.36758 19 9.50025C19 9.63292 18.9473 9.76017 18.8535 9.85398L14.7068 14L18.8535 18.146Z" fill="#0E0E0E"></path>
+          </svg>
+        </div>
+        {{/if}}
+               {{if canDelete && (!~inModal || depth > 0)}}
+                  <div x-data="{ threeDotsForAdmin: false, openedWithKeyboard: false }" class="relative w-fit" x-on:keydown.esc.window="threeDotsForAdmin = false, openedWithKeyboard = false">
+             <!-- Toggle Button -->
+             <div x-on:click="threeDotsForAdmin = ! threeDotsForAdmin" aria-haspopup="true" x-on:keydown.space.prevent="openedWithKeyboard = true" x-on:keydown.enter.prevent="openedWithKeyboard = true" class="cursor-pointer" x-on:keydown.down.prevent="openedWithKeyboard = true">
+               <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
+                 <path d="M13 12C13 12.2967 12.912 12.5867 12.7472 12.8334C12.5824 13.08 12.3481 13.2723 12.074 13.3858C11.7999 13.4993 11.4983 13.5291 11.2074 13.4712C10.9164 13.4133 10.6491 13.2704 10.4393 13.0607C10.2296 12.8509 10.0867 12.5836 10.0288 12.2926C9.97094 12.0017 10.0006 11.7001 10.1142 11.426C10.2277 11.1519 10.42 10.9176 10.6666 10.7528C10.9133 10.588 11.2033 10.5 11.5 10.5C11.8978 10.5 12.2794 10.658 12.5607 10.9393C12.842 11.2206 13 11.6022 13 12ZM11.5 5C11.7967 5 12.0867 4.91203 12.3334 4.74721C12.58 4.58238 12.7723 4.34811 12.8858 4.07403C12.9994 3.79994 13.0291 3.49834 12.9712 3.20737C12.9133 2.91639 12.7704 2.64912 12.5607 2.43934C12.3509 2.22956 12.0836 2.0867 11.7926 2.02882C11.5017 1.97094 11.2001 2.00065 10.926 2.11418C10.6519 2.22771 10.4176 2.41997 10.2528 2.66665C10.088 2.91332 10 3.20333 10 3.5C10 3.89783 10.158 4.27936 10.4393 4.56066C10.7206 4.84197 11.1022 5 11.5 5ZM11.5 19C11.2033 19 10.9133 19.088 10.6666 19.2528C10.42 19.4176 10.2277 19.6519 10.1142 19.926C10.0006 20.2001 9.97094 20.5017 10.0288 20.7926C10.0867 21.0836 10.2296 21.3509 10.4393 21.5607C10.6491 21.7704 10.9164 21.9133 11.2074 21.9712C11.4983 22.0291 11.7999 21.9993 12.074 21.8858C12.3481 21.7723 12.5824 21.58 12.7472 21.3334C12.912 21.0867 13 20.7967 13 20.5C13 20.1022 12.842 19.7206 12.5607 19.4393C12.2794 19.158 11.8978 19 11.5 19Z" fill="black" />
+               </svg>
+             </div>
+         <!-- Dropdown Menu -->
+         <div x-cloak x-show="threeDotsForAdmin || openedWithKeyboard" x-transition x-trap="openedWithKeyboard" x-on:click.outside="threeDotsForAdmin = false, openedWithKeyboard = false" x-on:keydown.down.prevent="$focus.wrap().next()" x-on:keydown.up.prevent="$focus.wrap().previous()" class="absolute top-11 rounded {{if !~inModal}}left-0{{else}}right-0{{/if}} bg-white p-2 flex w-fit min-w-48 flex-col overflow-hidden bg-white shadow-lg z-[999]" role="menu">
+           {{if depth === 0}}
+             {{if isAdmin}}
+
+             <div data-uid="{{:uid}}" class="btn-delete cursor-pointer p-2 text-nowrap text-black transition-all hover:bg-[var(--color-primary-shade)] rounded" role="menuitem">Delete this post</div>
+             {{if forumStatus === 'Published - Not flagged'}}
+                 {{if !isFeatured}}
+                 <div data-uid="{{:uid}}" class="btn-feature cursor-pointer p-2 text-nowrap text-black transition-all hover:bg-[var(--color-primary-shade)] rounded" role="menuitem">Mark this post as featured</div>
+                 {{else}}
+                 <div data-uid="{{:uid}}" class="btn-unfeature cursor-pointer p-2 text-nowrap text-black transition-all hover:bg-[var(--color-primary-shade)] rounded" role="menuitem">Remove featured mark</div>
+                 {{/if}}
+                 {{if commentsDisabled}}
+                 <div data-uid="{{:uid}}" class="btn-enable-comments cursor-pointer p-2 text-nowrap text-black transition-all hover:bg-[var(--color-primary-shade)] rounded" role="menuitem">Enable comments on this post</div>
+                 {{else}}
+                 <div data-uid="{{:uid}}" class="btn-disable-comments cursor-pointer p-2 text-nowrap text-black transition-all hover:bg-[var(--color-primary-shade)] rounded" role="menuitem">Disable comments on this post</div>
+                 {{/if}}
+             {{else}}
+               <div data-uid="{{:uid}}" class="postNowFromScheduled cursor-pointer p-2 text-nowrap text-black transition-all hover:bg-[var(--color-primary-shade)] rounded" role="menuitem">Post Now</div>
+             {{/if}}
+             {{else}}
+             {{if canDelete}}
+             <div data-uid="{{:uid}}" class="btn-delete cursor-pointer p-2 text-nowrap text-black transition-all hover:bg-[var(--color-primary-shade)] rounded" role="menuitem">Delete this post</div>
+             {{/if}}
+             {{/if}}
+           {{else}}
+           {{if canDelete}}
+             <div data-uid="{{:uid}}" class="btn-delete cursor-pointer p-2 text-nowrap text-black transition-all hover:bg-[var(--color-primary-shade)] rounded" role="menuitem">
+               {{if depth === 1}}Delete this comment{{else}}Delete this reply{{/if}}
+             </div>
+           {{/if}}
+           {{/if}}
+         </div>
+       </div>
+       {{/if}}
+
+       </div>
+     {{if content !=''  }} <div class="content">{{:content}}</div>{{/if}}
+       {{if fileContent || fileContentComment}}
+         <div class="file-preview {{if fileType === "Audio"}}bg-[var(--grey-300)] p-3 rounded{{/if}}">
+          {{if fileType === "Audio" && depth === 0}}
+             <div class="h2 text-black mb-4">{{:fileContentName}}</div>
+           {{/if}}
+           {{if depth === 0 && fileContent}}
+
+                            {{if fileType === "Image"}}
+                              <img src="{{:fileContent}}" style="width:100%;height:300px;object-fit:cover;" alt="preview" />
+                            {{else fileType === "Audio"}}
+                              <audio class="js-player" controls>
+                                <source src="{{:fileContent}}" type="audio/mpeg" />
+                                Your browser does not support the audio tag.
+                              </audio>
+                            {{else fileType === "Video"}}
+                              <video preload="auto" class="js-player" controls style="width: 100%; height: auto;">
+                                <source src="{{:fileContent}}" type="video/mp4" />
+                                Your browser does not support video.
+                              </video>
+                            {{else}}
+                              <a href="{{:fileContent}}"class="flex w-full flex-col items-start justify-center gap-4 self-stretch rounded bg-zinc-100 p-2">
+                                <div class="inline-flex items-center justify-start gap-2 self-stretch rounded-xl">
+                                  <div class="flex items-center justify-start gap-3">
+                                    <svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                      <path d="M28.0316 9.85346L20.4931 2.315C20.3931 2.21502 20.2743 2.13575 20.1435 2.0817C20.0128 2.02765 19.8727 1.99989 19.7312 2H6.80814C6.23691 2 5.68907 2.22692 5.28514 2.63085C4.88122 3.03477 4.6543 3.58261 4.6543 4.15385V27.8462C4.6543 28.4174 4.88122 28.9652 5.28514 29.3692C5.68907 29.7731 6.23691 30 6.80814 30H26.1928C26.764 30 27.3118 29.7731 27.7158 29.3692C28.1197 28.9652 28.3466 28.4174 28.3466 27.8462V10.6154C28.3467 10.4739 28.319 10.3338 28.2649 10.2031C28.2109 10.0724 28.1316 9.95355 28.0316 9.85346ZM19.7312 20.3077H13.2697C12.9841 20.3077 12.7101 20.1942 12.5082 19.9923C12.3062 19.7903 12.1928 19.5164 12.1928 19.2308C12.1928 18.9452 12.3062 18.6712 12.5082 18.4693C12.7101 18.2673 12.9841 18.1538 13.2697 18.1538H19.7312C20.0168 18.1538 20.2908 18.2673 20.4927 18.4693C20.6947 18.6712 20.8081 18.9452 20.8081 19.2308C20.8081 19.5164 20.6947 19.7903 20.4927 19.9923C20.2908 20.1942 20.0168 20.3077 19.7312 20.3077ZM19.7312 10.6154V4.59942L25.7472 10.6154H19.7312Z" fill="#0963D8" />
+                                    </svg>
+                                    <div class="inline-flex flex-col items-start justify-center gap-1">
+                                      <div class="h3 justify-start text-center font-['Inter'] text-black">{{:fileContentName}}</div>
+                                      <div class="p3 justify-start text-center font-['Inter'] text-[var(--color-grey)]">{{:fileSize}}</div>
+                                    </div>
+                                  </div>
+                                </div>
+                              </a>
+                         {{/if}}
+               
+           {{/if}}
+           {{if depth > 0 && fileContentComment}}
+                 {{if fileType === "Image"}}
+                   <img src="{{:fileContentComment}}" style="width:211px;height:138px;object-fit:contain;" alt="preview" />
+                 {{else fileType === "Audio"}}
+                 <label for="audio-player">{{:fileContentCommentName}}</label>
+                   <audio class="js-player" controls>
+                     <source src="{{:fileContentComment}}" type="audio/mpeg" />
+                     Your browser does not support the audio tag.
+                   </audio>
+
+                 {{else fileType === "Video"}}
+                   <video preload="auto" class="js-player" controls style="width: 100%; height: auto;">
+                     <source src="{{:fileContentComment}}" type="video/mp4" />
+                     Your browser does not support video.
+                   </video>
+                 {{else}}
+                 <a href="{{:fileContentComment}}"class="flex w-full flex-col items-start justify-center gap-4 self-stretch rounded bg-zinc-100 p-2">
+                  <div class="inline-flex items-center justify-start gap-2 self-stretch rounded-xl">
+                    <div class="flex items-center justify-start gap-3">
+                      <svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+                        <path d="M28.0316 9.85346L20.4931 2.315C20.3931 2.21502 20.2743 2.13575 20.1435 2.0817C20.0128 2.02765 19.8727 1.99989 19.7312 2H6.80814C6.23691 2 5.68907 2.22692 5.28514 2.63085C4.88122 3.03477 4.6543 3.58261 4.6543 4.15385V27.8462C4.6543 28.4174 4.88122 28.9652 5.28514 29.3692C5.68907 29.7731 6.23691 30 6.80814 30H26.1928C26.764 30 27.3118 29.7731 27.7158 29.3692C28.1197 28.9652 28.3466 28.4174 28.3466 27.8462V10.6154C28.3467 10.4739 28.319 10.3338 28.2649 10.2031C28.2109 10.0724 28.1316 9.95355 28.0316 9.85346ZM19.7312 20.3077H13.2697C12.9841 20.3077 12.7101 20.1942 12.5082 19.9923C12.3062 19.7903 12.1928 19.5164 12.1928 19.2308C12.1928 18.9452 12.3062 18.6712 12.5082 18.4693C12.7101 18.2673 12.9841 18.1538 13.2697 18.1538H19.7312C20.0168 18.1538 20.2908 18.2673 20.4927 18.4693C20.6947 18.6712 20.8081 18.9452 20.8081 19.2308C20.8081 19.5164 20.6947 19.7903 20.4927 19.9923C20.2908 20.1942 20.0168 20.3077 19.7312 20.3077ZM19.7312 10.6154V4.59942L25.7472 10.6154H19.7312Z" fill="#0963D8" />
+                      </svg>
+                      <div class="inline-flex flex-col items-start justify-center gap-1">
+                        <div class="h3 justify-start text-center font-['Inter'] text-black">{{:fileContentCommentName}}</div>
+                        <div class="p3 justify-start text-center font-['Inter'] text-[var(--color-grey)]">{{:fileSize}}</div>
+                      </div>
+                    </div>
+                  </div>
+                </a>
+             {{/if}}
+           {{/if}}
+         </div>
+       {{/if}}
+         <div class=" flex items-center gap-4">
+  <div class="flex items-end justify-end gap-2 ">
+    <svg width="17" height="16" viewBox="0 0 17 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path d="M14.6732 6.30021C14.5455 6.15556 14.3885 6.03972 14.2127 5.96038C14.0368 5.88105 13.8461 5.84004 13.6532 5.84008H10.4798V4.93341C10.4798 4.33226 10.241 3.75572 9.81593 3.33064C9.39085 2.90556 8.81431 2.66675 8.21316 2.66675C8.12894 2.66669 8.04637 2.69009 7.9747 2.73433C7.90304 2.77857 7.84511 2.8419 7.80742 2.91721L5.66656 7.20008H3.22649C2.98603 7.20008 2.75541 7.2956 2.58538 7.46564C2.41535 7.63567 2.31982 7.86628 2.31982 8.10675V13.0934C2.31982 13.3339 2.41535 13.5645 2.58538 13.7345C2.75541 13.9046 2.98603 14.0001 3.22649 14.0001H12.9732C13.3045 14.0002 13.6245 13.8793 13.873 13.6602C14.1215 13.4411 14.2815 13.1388 14.323 12.8101L15.003 7.37008C15.0271 7.17856 15.0101 6.9841 14.9533 6.79964C14.8964 6.61517 14.8009 6.44493 14.6732 6.30021ZM3.22649 8.10675H5.49316V13.0934H3.22649V8.10675Z" fill="var(--color-primary)" />
+    </svg>
+    <div class="p3 text-[var(--color-primary)]">{{:upvotes}}</div>
+  </div>
+  {{if !commentsDisabled && forumStatus !== 'Scheduled'}}
+  <div class="flex items-end justify-end gap-2 {{if depth === 1}}cursor-pointer toggle-replies{{/if}}" {{if depth === 1}}data-uid="{{:uid}}"{{/if}}>
+    <svg width="17" height="16" viewBox="0 0 17 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path d="M11.1668 7.19992C11.1668 7.34137 11.1106 7.47702 11.0106 7.57704C10.9106 7.67706 10.7749 7.73325 10.6335 7.73325H6.10016C5.95871 7.73325 5.82306 7.67706 5.72304 7.57704C5.62302 7.47702 5.56683 7.34137 5.56683 7.19992C5.56683 7.05847 5.62302 6.92281 5.72304 6.82279C5.82306 6.72278 5.95871 6.66658 6.10016 6.66658H10.6335C10.7749 6.66658 10.9106 6.72278 11.0106 6.82279C11.1106 6.92281 11.1668 7.05847 11.1668 7.19992ZM10.6335 8.79992H6.10016C5.95871 8.79992 5.82306 8.85611 5.72304 8.95613C5.62302 9.05615 5.56683 9.1918 5.56683 9.33325C5.56683 9.4747 5.62302 9.61036 5.72304 9.71038C5.82306 9.8104 5.95871 9.86658 6.10016 9.86658H10.6335C10.7749 9.86658 10.9106 9.8104 11.0106 9.71038C11.1106 9.61036 11.1668 9.4747 11.1668 9.33325C11.1668 9.1918 11.1106 9.05615 11.0106 8.95613C10.9106 8.85611 10.7749 8.79992 10.6335 8.79992ZM15.1668 7.99992C15.1649 9.76743 14.4619 11.462 13.2121 12.7118C11.9622 13.9616 10.2677 14.6646 8.50016 14.6666H2.90016C2.61727 14.6666 2.34595 14.5542 2.14592 14.3542C1.94588 14.1541 1.8335 13.8828 1.8335 13.5999V7.99992C1.8335 6.23181 2.53588 4.53612 3.78612 3.28587C5.03636 2.03563 6.73205 1.33325 8.50016 1.33325C10.2683 1.33325 11.964 2.03563 13.2142 3.28587C14.4644 4.53612 15.1668 6.23181 15.1668 7.99992ZM14.1002 7.99992C14.1002 6.51471 13.5102 5.09032 12.46 4.04012C11.4098 2.98992 9.98537 2.39992 8.50016 2.39992C7.01495 2.39992 5.59057 2.98992 4.54036 4.04012C3.49016 5.09032 2.90016 6.51471 2.90016 7.99992V13.5999H8.50016C9.98489 13.5983 11.4083 13.0078 12.4582 11.958C13.5081 10.9081 14.0986 9.48464 14.1002 7.99992Z" fill="var(--color-primary)" />
+    </svg>
+    <div class="p3 text-[var(--color-primary)]">
+      {{if depth === 1}}
+        {{:children.length}}
+      {{else depth === 0}}
+        {{:~totalComments(children)}}
+      {{else}}
+        {{:children.length}}
+      {{/if}}
+    </div>
+  </div>
+  {{/if}}
+</div>
+       {{if forumStatus === 'Published - Not flagged'}}
+       <div class="flex items-center gap-4 border-t border-[var(--grey-200)] pt-[14px] actions">
+  <div class="flex flex-1 items-center justify-center gap-2 cursor-pointer btn-like {{:hasUpvoted ? ' liked' : ''}}" data-uid="{{:uid}}">
+    <svg width="17" height="16" viewBox="0 0 17 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path d="M14.6732 6.30021C14.5455 6.15556 14.3885 6.03972 14.2127 5.96038C14.0368 5.88105 13.8461 5.84004 13.6532 5.84008H10.4798V4.93341C10.4798 4.33226 10.241 3.75572 9.81593 3.33064C9.39085 2.90556 8.81431 2.66675 8.21316 2.66675C8.12894 2.66669 8.04637 2.69009 7.9747 2.73433C7.90304 2.77857 7.84511 2.8419 7.80742 2.91721L5.66656 7.20008H3.22649C2.98603 7.20008 2.75541 7.2956 2.58538 7.46564C2.41535 7.63567 2.31982 7.86628 2.31982 8.10675V13.0934C2.31982 13.3339 2.41535 13.5645 2.58538 13.7345C2.75541 13.9046 2.98603 14.0001 3.22649 14.0001H12.9732C13.3045 14.0002 13.6245 13.8793 13.873 13.6602C14.1215 13.4411 14.2815 13.1388 14.323 12.8101L15.003 7.37008C15.0271 7.17856 15.0101 6.9841 14.9533 6.79964C14.8964 6.61517 14.8009 6.44493 14.6732 6.30021ZM3.22649 8.10675H5.49316V13.0934H3.22649V8.10675Z" fill="#0E0E0E" />
+    </svg>
+    <div class="p3">Like</div>
+  </div>
+  
+   {{if !commentsDisabled && forumStatus !== 'Scheduled'}}
+  <div class="flex {{if ~inModal}}btn-comment{{else}}openPostModal{{/if}} flex-1 items-center justify-center gap-2 cursor-pointer" data-uid="{{:uid}}"   data-id="{{:id}}" data-author="{{:authorName}}"
+  {{if !~inModal}} @click="modalForPostOpen=true"{{/if}}>
+    <svg width="17" height="16" viewBox="0 0 17 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path d="M11.1668 7.19992C11.1668 7.34137 11.1106 7.47702 11.0106 7.57704C10.9106 7.67706 10.7749 7.73325 10.6335 7.73325H6.10016C5.95871 7.73325 5.82306 7.67706 5.72304 7.57704C5.62302 7.47702 5.56683 7.34137 5.56683 7.19992C5.56683 7.05847 5.62302 6.92281 5.72304 6.82279C5.82306 6.72278 5.95871 6.66658 6.10016 6.66658H10.6335C10.7749 6.66658 10.9106 6.72278 11.0106 6.82279C11.1106 6.92281 11.1668 7.05847 11.1668 7.19992ZM10.6335 8.79992H6.10016C5.95871 8.79992 5.82306 8.85611 5.72304 8.95613C5.62302 9.05615 5.56683 9.1918 5.56683 9.33325C5.56683 9.4747 5.62302 9.61036 5.72304 9.71038C5.82306 9.8104 5.95871 9.86658 6.10016 9.86658H10.6335C10.7749 9.86658 10.9106 9.8104 11.0106 9.71038C11.1106 9.61036 11.1668 9.4747 11.1668 9.33325C11.1668 9.1918 11.1106 9.05615 11.0106 8.95613C10.9106 8.85611 10.7749 8.79992 10.6335 8.79992ZM15.1668 7.99992C15.1649 9.76743 14.4619 11.462 13.2121 12.7118C11.9622 13.9616 10.2677 14.6646 8.50016 14.6666H2.90016C2.61727 14.6666 2.34595 14.5542 2.14592 14.3542C1.94588 14.1541 1.8335 13.8828 1.8335 13.5999V7.99992C1.8335 6.23181 2.53588 4.53612 3.78612 3.28587C5.03636 2.03563 6.73205 1.33325 8.50016 1.33325C10.2683 1.33325 11.964 2.03563 13.2142 3.28587C14.4644 4.53612 15.1668 6.23181 15.1668 7.99992ZM14.1002 7.99992C14.1002 6.51471 13.5102 5.09032 12.46 4.04012C11.4098 2.98992 9.98537 2.39992 8.50016 2.39992C7.01495 2.39992 5.59057 2.98992 4.54036 4.04012C3.49016 5.09032 2.90016 6.51471 2.90016 7.99992V13.5999H8.50016C9.98489 13.5983 11.4083 13.0078 12.4582 11.958C13.5081 10.9081 14.0986 9.48464 14.1002 7.99992Z" fill="#0E0E0E" />
+    </svg>
+    <div class="p3">{{if depth === 0}}Comment{{else}}Reply{{/if}}</div>
+  </div>
+  {{/if}}
+  {{if depth === 0}}
+  <div class="flex flex-1 items-center justify-center gap-2 cursor-pointer btn-bookmark {{:hasBookmarked ? ' bookmarked' : ''}}" data-uid="{{:uid}}">
+    <svg width="17" height="16" viewBox="0 0 17 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path d="M12.7 1.33325H5.23319C4.95029 1.33325 4.67897 1.44563 4.47893 1.64568C4.27889 1.84572 4.1665 2.11704 4.1665 2.39994V14.1335C4.16655 14.2287 4.19207 14.3221 4.24041 14.4041C4.28875 14.4861 4.35815 14.5537 4.44142 14.5998C4.52468 14.6459 4.61876 14.6689 4.71391 14.6664C4.80906 14.6639 4.90181 14.636 4.98252 14.5855L8.9666 12.0955L12.9513 14.5855C13.032 14.6358 13.1247 14.6636 13.2198 14.666C13.3148 14.6684 13.4088 14.6454 13.4919 14.5993C13.5751 14.5532 13.6444 14.4857 13.6927 14.4038C13.741 14.3219 13.7666 14.2286 13.7667 14.1335V2.39994C13.7667 2.11704 13.6543 1.84572 13.4543 1.64568C13.2542 1.44563 12.9829 1.33325 12.7 1.33325Z" fill="#0E0E0E" />
+    </svg>
+    <div class="p3">{{:hasBookmarked ? ' Saved' : 'Save'}}</div>
+  </div>
+  {{/if}}
+</div>
+       {{/if}}
+              {{!-- Toggle replies ribbon below comment --}}
+               {{if depth === 1 && children.length}}
+                 <div class="reply-ribbon cursor-pointer toggle-replies" data-uid="{{:uid}}">
+                   {{if isCollapsed}}
+                     View {{:children.length}} replies
+                   {{else}}
+                     Hide replies
+                   {{/if}}
+                 </div>
+               {{/if}}
+               {{if children.length && !isCollapsed}}
+                 <div data-reply="{{:uid}}" class="children visible my-4 {{:depth < 2 ? 'pl-6 ml-[12px] border-l border-2-[#e9ebee]' : ''}}">
+                   {{for children}}
+                     {{include tmpl="#tmpl-comment"/}}
+                   {{/for}}
+                 </div>
+               {{/if}}
+             </div>
+             {{/if}}
+    </script>
   <script src="https://unpkg.com/mic-recorder-to-mp3@2.2.1/dist/index.min.js"></script>
 
   <script type="module" src="../src/main.js"></script>

--- a/src/features/posts/filters.js
+++ b/src/features/posts/filters.js
@@ -1,6 +1,6 @@
 import { state, searchInput, clearIcon, searchIcon, GLOBAL_AUTHOR_ID } from "../../config.js";
 import { downCevron } from "../../ui/emoji.js";
-import { tmpl } from "../../ui/render.js";
+import { renderItems } from "../../ui/render.js";
 import { setupPlyr } from "../../utils/plyr.js";
 export function applyFilterAndRender() {
   const skeleton = document.getElementById('skeleton-loader');
@@ -76,7 +76,7 @@ export function applyFilterAndRender() {
       }
     });
 
-    $container.html(tmpl.render(items, { inModal: false }));
+    $container.html(renderItems(items, { inModal: false }));
 
     for (const uid in frames) {
       const $item = $container.find(`[data-uid="${uid}"]`);

--- a/src/features/posts/postModal.js
+++ b/src/features/posts/postModal.js
@@ -1,6 +1,6 @@
 import { GET_SINGLE_POST_SUBSCRIPTION } from "../../api/queries.js";
 import { buildTree } from "../../ui/render.js";
-import { tmpl } from "../../ui/render.js";
+import { renderItems } from "../../ui/render.js";
 import { setupPlyr } from "../../utils/plyr.js";
 import { PROTOCOL, WS_ENDPOINT, KEEPALIVE_MS } from "../../config.js";
 
@@ -8,7 +8,7 @@ let modalTree = [];
 function renderModal() {
   const container = document.getElementById("modalForumRoot");
   if (!container) return;
-  container.innerHTML = tmpl.render(modalTree, { inModal: true });
+  container.innerHTML = renderItems(modalTree, { inModal: true });
   requestAnimationFrame(() => {
     setupPlyr();
   });

--- a/src/ui/render.js
+++ b/src/ui/render.js
@@ -135,4 +135,15 @@ export function findNode(arr, uid) {
   return null;
 }
 
-export const tmpl = $.templates("#tmpl-item");
+export const tmplPost = $.templates("#tmpl-post");
+export const tmplComment = $.templates("#tmpl-comment");
+
+export function renderItems(items, data) {
+  return items
+    .map((item) =>
+      item.depth === 0
+        ? tmplPost.render(item, data)
+        : tmplComment.render(item, data)
+    )
+    .join("");
+}


### PR DESCRIPTION
## Summary
- split templates for posts versus comments
- add renderItems helper to choose the correct template
- update modal and filter rendering to use new helper

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find module 'globals')*

------
https://chatgpt.com/codex/tasks/task_b_6854fadce138832192d638d86d8b1e5c