### PR TITLE
Fix comment-to-ribbon connector

### DIFF
--- a/public/styles/style.css
+++ b/public/styles/style.css
@@ -493,9 +493,7 @@ button:not(.file-preview button):hover {
   top: 100%;
   left: 50%;
   transform: translateX(-50%);
-  width: 2px;
-  background-color: black;
-  height: 100px;
-  /* To be dynamically updated */
+  pointer-events: none;
+  /* Line styles applied dynamically */
 }
 /* Dropdown UI */

--- a/src/main.js
+++ b/src/main.js
@@ -172,9 +172,13 @@ function updateLines() {
     if (ribbon && ribbon.classList.contains('ribbonForOpeningReplies')) {
       const commentRect = comment.getBoundingClientRect();
       const ribbonRect = ribbon.getBoundingClientRect();
-      const distance = ribbonRect.top - commentRect.bottom;
+      const verticalDistance =
+        ribbonRect.top + ribbonRect.height / 2 - commentRect.bottom;
+      const horizontalDistance =
+        ribbonRect.left - (commentRect.left + commentRect.width / 2);
 
-      comment.style.setProperty('--line-height', `${distance}px`);
+      comment.style.setProperty('--line-height', `${verticalDistance}px`);
+      comment.style.setProperty('--line-horizontal', `${horizontalDistance}px`);
       comment.classList.add('line-ready');
     }
   });
@@ -184,6 +188,10 @@ const style = document.createElement('style');
 style.textContent = `
     .mainComment.line-ready::after {
         height: var(--line-height);
+        width: var(--line-horizontal);
+        border-left: 2px solid black;
+        border-bottom: 2px solid black;
+        box-sizing: border-box;
     }
 `;
 document.head.appendChild(style);


### PR DESCRIPTION
## Summary
- adjust `.mainComment::after` baseline styles
- compute connector width and height in `updateLines`
- style pseudo-element to draw an L‑shaped line from comment to ribbon

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68553100161c8321bef304932ad63a5f