### PR TITLE
Filter non-admin forum posts by status

### DIFF
--- a/src/ws.js
+++ b/src/ws.js
@@ -71,7 +71,7 @@ export function connect() {
           id: SUB_ID,
           type: "GQL_START",
           payload: {
-            query: SUBSCRIBE_FORUM_POSTS,
+            query: SUBSCRIBE_FORUM_POSTS(state.userRole === "admin"),
             variables: { forum_tag: GLOBAL_PAGE_TAG }
           }
         })


### PR DESCRIPTION
## Summary
- tweak forum post subscription to filter for published posts when not admin
- generate subscription query dynamically based on user role

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find module 'globals')*

------
https://chatgpt.com/codex/tasks/task_b_68590c9ac534832183f3ad9e2f445b69