### PR TITLE
Add body scroll lock for modals

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -38,12 +38,16 @@
     showSettings: false,
     modalForPostOpen:false,
     openSettings:false,
-    openScheduleDatePicker: false, 
+    openScheduleDatePicker: false,
     modalForCustomDateTime: false,
-    selectedDate: '', 
-    today: new Date().toISOString().split('T')[0] 
-   
-}" class="max-w-[700px] max-[700px]:!w-full bg-[#f1f1f1] flex flex-col items-center min-[702px]:justify-center m-auto p-6 max-[768px]:p-0">
+    selectedDate: '',
+    today: new Date().toISOString().split('T')[0]
+}"
+  x-init="
+    $watch('modalForPostOpen', v => v ? window.disableBodyScroll() : window.enableBodyScroll());
+    $watch('modalForCustomDateTime', v => v ? window.disableBodyScroll() : window.enableBodyScroll());
+  "
+  class="max-w-[700px] max-[700px]:!w-full bg-[#f1f1f1] flex flex-col items-center min-[702px]:justify-center m-auto p-6 max-[768px]:p-0">
   <!--Modal for custom date and time end  -->
   <!-- Modal For Post starts -->
   <div x-cloak x-show="modalForPostOpen" x-transition.opacity.duration.200ms x-trap.inert.noscroll="modalForPostOpen"
@@ -288,7 +292,9 @@
 
   <!--Modal for custom date and time end  -->
 
-  <div x-data="{modalToSelectUser: true}" class="fixed bottom-[4rem] right-[1rem] z-[99999]">
+  <div x-data="{modalToSelectUser: true}"
+    x-init="$watch('modalToSelectUser', v => v ? window.disableBodyScroll() : window.enableBodyScroll())"
+    class="fixed bottom-[4rem] right-[1rem] z-[99999]">
     <button @click="switchUser=true; modalToSelectUser=true"
       class="p-3 bg-[var(--color-primary)] flex items-center justify-center cursor-pointer max-[768px]:hidden z-[99]">
       <i class="fa-solid fa-arrows-rotate"></i>

--- a/src/domEvents.js
+++ b/src/domEvents.js
@@ -6,6 +6,7 @@ import {
 } from "./api/queries.js";
 import { fetchGraphQL } from "./api/fetch.js";
 import { showToast } from "./ui/toast.js";
+import { disableBodyScroll, enableBodyScroll } from "./utils/bodyScroll.js";
 
 function renderContacts(list, containerId) {
   const container = document.getElementById(containerId);
@@ -74,6 +75,7 @@ export function setupCreatePostModal() {
     trigger.addEventListener("click", () => {
       modal.classList.remove("hidden");
       modal.classList.add("show");
+      disableBodyScroll();
       document.getElementById("post-editor").focus();
     });
   }
@@ -82,6 +84,7 @@ export function setupCreatePostModal() {
     closeBtn.addEventListener("click", () => {
       modal.classList.add("hidden");
       modal.classList.remove("show");
+      enableBodyScroll();
     });
   }
 

--- a/src/features/posts/moderation.js
+++ b/src/features/posts/moderation.js
@@ -9,6 +9,7 @@ import { applyFilterAndRender } from "./filters.js";
 import { getModalTree, rerenderModal } from "./postModal.js";
 import { removeRawById, findRawById } from "../../utils/posts.js";
 import { showToast } from "../../ui/toast.js";
+import { disableBodyScroll, enableBodyScroll } from "../../utils/bodyScroll.js";
 
 const deleteModal = document.getElementById("delete-modal");
 const deleteModalTitle = document.getElementById("delete-modal-title");
@@ -41,10 +42,12 @@ export function initModerationHandlers() {
     const label = node.depth === 0 ? "post" : node.depth === 1 ? "comment" : "reply";
     deleteModalTitle.textContent = `Do you want to delete this ${label}?`;
     deleteModal.classList.remove("hidden");
+    disableBodyScroll();
   });
 
   $(document).on("click", "#delete-cancel", function () {
     deleteModal.classList.add("hidden");
+    enableBodyScroll();
     pendingDelete = null;
   });
 
@@ -52,6 +55,7 @@ export function initModerationHandlers() {
     if (!pendingDelete) return;
     const { uid, inModal } = pendingDelete;
     deleteModal.classList.add("hidden");
+    enableBodyScroll();
     const $item = $(`[data-uid="${uid}"]`).closest(".item");
     $item.addClass("state-disabled");
 

--- a/src/features/posts/preview.js
+++ b/src/features/posts/preview.js
@@ -1,3 +1,5 @@
+import { disableBodyScroll, enableBodyScroll } from "../../utils/bodyScroll.js";
+
 export function initPreviewHandlers() {
 // File preview modal logic
 const previewModal = document.getElementById('file-preview-modal');
@@ -10,6 +12,7 @@ if (previewClose) {
     previewModal.classList.add('hidden');
     previewModal.classList.remove('show');
     previewContainer.innerHTML = '';
+    enableBodyScroll();
   });
 }
 
@@ -54,6 +57,7 @@ $(document).on(
     }
     previewModal.classList.remove('hidden');
     previewModal.classList.add('show');
+    disableBodyScroll();
   }
 );
 }

--- a/src/main.js
+++ b/src/main.js
@@ -18,12 +18,15 @@ import { renderNotificationToggles } from "./ui/notificationPreference.js";
 import { toggleAllOff, toggleOption } from "./ui/notificationPreference.js";
 import { showToast } from "./ui/toast.js";
 import { refreshNotificationSubscription } from "./notifications.js";
+import { disableBodyScroll, enableBodyScroll } from "./utils/bodyScroll.js";
 export let notificationPreferences = null;
 
 window.createForumToSubmit = createForumToSubmit;
 window.toggleAllOff = toggleAllOff;
 window.toggleOption = toggleOption;
 window.state = state;
+window.disableBodyScroll = disableBodyScroll;
+window.enableBodyScroll = enableBodyScroll;
 
 export function getNotificationPreferences(contactId) {
   return fetchGraphQL(GET__CONTACTS_NOTIFICATION_PREFERENCEE, { id: contactId })

--- a/src/utils/bodyScroll.js
+++ b/src/utils/bodyScroll.js
@@ -1,0 +1,17 @@
+let openModals = 0;
+
+export function disableBodyScroll() {
+  openModals++;
+  if (openModals === 1) {
+    document.body.classList.add('overflow-hidden');
+  }
+}
+
+export function enableBodyScroll() {
+  if (openModals > 0) {
+    openModals--;
+  }
+  if (openModals === 0) {
+    document.body.classList.remove('overflow-hidden');
+  }
+}


### PR DESCRIPTION
## Summary
- prevent page scrolling while any modal is shown
- expose utility functions on window to toggle body scroll
- call scroll toggle helpers from custom modal scripts
- watch Alpine modal state in HTML to toggle scroll

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find module 'globals')*

------
https://chatgpt.com/codex/tasks/task_b_68592bd639148321b496d4cef033e4e9