### PR TITLE
Add default avatar to mentions

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -62,7 +62,7 @@ function startApp(tagName, contactId, displayName) {
       tribute.collection[0].values = contacts.map((c) => ({
         key: c.Display_Name || "Anonymous",
         value: c.Contact_ID,
-        image: c.Profile_Image,
+        image: c.Profile_Image || DEFAULT_AVATAR,
       }));
       const current = contacts.find((c) => c.Contact_ID === GLOBAL_AUTHOR_ID);
       if (current) {

--- a/src/utils/tribute.js
+++ b/src/utils/tribute.js
@@ -1,10 +1,12 @@
+import { DEFAULT_AVATAR } from "../config.js";
+
 export const tribute = new Tribute({
     collection: [
       {
         trigger: "@",
         menuItemTemplate: (item) =>
           `<div class="mention-item flex items-center gap-4">
-           <img src="${item.original.image}" width="24" height="24" class = "rounded-full"/>
+           <img src="${item.original.image || DEFAULT_AVATAR}" width="24" height="24" class = "rounded-full"/>
            <span class = "font-light text-sm">${item.string}</span>
          </div>`,
         selectTemplate: (item) =>


### PR DESCRIPTION
## Summary
- show a fallback avatar for mention items
- provide a default avatar URL when creating mention items

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find module 'globals')*

------
https://chatgpt.com/codex/tasks/task_b_68592d9933d083218342e654b1302dd8