### PR TITLE
Add mark-all loading overlay

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -111,6 +111,9 @@
         <!-- Notification Panel -->
         <div x-show="showNotifications" @click.outside="showNotifications = false" x-transition
           class="absolute right-0 mt-2 w-96 bg-white rounded-lg shadow-lg z-[50000] p-4 max-[702px]:fixed max-[702px]:w-full">
+          <div class="absolute notificationsLoader hidden inset-0 bg-[#00000095] z-10 items-center justify-center flex">
+            <div class="h-8 w-8 animate-spin rounded-full border-2 border-solid border-white border-t-transparent"></div>
+          </div>
           <div class="flex items-center justify-between mb-3">
             <h3 class="font-semibold text-lg">Notifications</h3>
             <div class="flex items-center gap-3 text-gray-500">

--- a/src/notifications.js
+++ b/src/notifications.js
@@ -210,6 +210,9 @@ export function initNotificationEvents() {
     `;
 
     try {
+      if (markAll) {
+        $(".notificationsLoader").removeClass("hidden").addClass("flex");
+      }
       await fetchGraphQL(UPDATE_ANNOUNCEMENT, variables, UPDATE_ANNOUNCEMENT);
 
       if (markAll) {
@@ -229,6 +232,10 @@ export function initNotificationEvents() {
       }
     } catch (error) {
       console.error("Error marking announcement(s) as read:", error);
+    } finally {
+      if (markAll) {
+        $(".notificationsLoader").removeClass("flex").addClass("hidden");
+      }
     }
   });
 }


### PR DESCRIPTION
## Summary
- show a loading indicator over notifications dropdown while 'Mark all' is processing

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find module 'globals')*


------
https://chatgpt.com/codex/tasks/task_b_685a5c63c6408321b4c6b417e9e8041e