### PR TITLE
Fix media playback when closing modals

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -43,7 +43,14 @@
     selectedDate: '',
     today: new Date().toISOString().split('T')[0]
 }" x-init="
-    $watch('modalForPostOpen', v => v ? window.disableBodyScroll() : window.enableBodyScroll());
+    $watch('modalForPostOpen', v => {
+      if (v) {
+        window.disableBodyScroll();
+      } else {
+        window.enableBodyScroll();
+        window.pauseAllPlayers?.();
+      }
+    });
     $watch('modalForCustomDateTime', v => v ? window.disableBodyScroll() : window.enableBodyScroll());
   "
   class="max-w-[700px] max-[700px]:!w-full bg-[#f1f1f1] flex flex-col items-center min-[702px]:justify-center m-auto p-6 max-[768px]:p-0">

--- a/src/features/posts/preview.js
+++ b/src/features/posts/preview.js
@@ -1,4 +1,5 @@
 import { disableBodyScroll, enableBodyScroll } from "../../utils/bodyScroll.js";
+import { pauseAllPlayers } from "../../utils/plyr.js";
 
 export function initPreviewHandlers() {
 // File preview modal logic
@@ -11,6 +12,7 @@ if (previewClose) {
   previewClose.addEventListener('click', () => {
     previewModal.classList.add('hidden');
     previewModal.classList.remove('show');
+    pauseAllPlayers(previewContainer);
     previewContainer.innerHTML = '';
     enableBodyScroll();
   });

--- a/src/main.js
+++ b/src/main.js
@@ -1,7 +1,7 @@
 import { state,notificationStore, GLOBAL_AUTHOR_ID, DEFAULT_AVATAR, GLOBAL_PAGE_TAG } from "./config.js";
 import { setGlobals } from "./config.js";
 import { FETCH_CONTACTS_QUERY, GET_CONTACTS_BY_TAGS, GET__CONTACTS_NOTIFICATION_PREFERENCEE, UPDATE_CONTACT_NOTIFICATION_PREFERENCE } from "./api/queries.js";
-import { setupPlyr } from "./utils/plyr.js";
+import { setupPlyr, pauseAllPlayers } from "./utils/plyr.js";
 import { fetchGraphQL } from "./api/fetch.js";
 import { tribute } from "./utils/tribute.js";
 import { initFilePond } from "./utils/filePond.js";
@@ -27,6 +27,7 @@ window.toggleOption = toggleOption;
 window.state = state;
 window.disableBodyScroll = disableBodyScroll;
 window.enableBodyScroll = enableBodyScroll;
+window.pauseAllPlayers = pauseAllPlayers;
 
 export function getNotificationPreferences(contactId) {
   return fetchGraphQL(GET__CONTACTS_NOTIFICATION_PREFERENCEE, { id: contactId })

--- a/src/utils/plyr.js
+++ b/src/utils/plyr.js
@@ -32,3 +32,13 @@ export function setupPlyr() {
     }
   });
 }
+
+export function pauseAllPlayers(root = document) {
+  root.querySelectorAll('.js-player').forEach((el) => {
+    if (el.plyr && typeof el.plyr.pause === 'function') {
+      el.plyr.pause();
+    } else if (typeof el.pause === 'function') {
+      el.pause();
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- expose a global pauseAllPlayers function
- stop playback when closing the file preview modal
- pause all players when closing the post modal

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find module 'globals')*

------
https://chatgpt.com/codex/tasks/task_b_685be529d2488321bf3ed71212a61aba