### PR TITLE
Highlight comments from notifications

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -176,7 +176,7 @@ class="max-w-[700px] max-[700px]:!w-full bg-[#f1f1f1] flex flex-col items-center
           </div>
 
         <script id="notificationTemplate" type="text/x-jsrender">
-                                    <div class="notification {{if Is_Read}}read{{else}}unread{{/if}} cursor-pointer flex items-start gap-3 rounded-lg p-3 hover:bg-gray-100" data-announcement="{{:ID}}"  data-parentForumid="{{:Parent_Forum_If_Not_A_Post || Parent_Forum_ID}}" @click="modalForPostOpen=true">
+                                    <div class="notification {{if Is_Read}}read{{else}}unread{{/if}} cursor-pointer flex items-start gap-3 rounded-lg p-3 hover:bg-gray-100" data-announcement="{{:ID}}"  data-parentForumid="{{:Parent_Forum_If_Not_A_Post || Parent_Forum_ID}}" data-targetid="{{:Parent_Forum_ID}}" data-notiftype="{{:Notification_Type}}" @click="modalForPostOpen=true">
                                       <i class="fa-solid fa-file-alt mt-1 text-lg text-indigo-500"></i>
                                       <div class="flex-1">
                                         <div class="p3 text-[var(--color-black)]">{{:Title}}</div>

--- a/public/styles/style.css
+++ b/public/styles/style.css
@@ -540,6 +540,17 @@ button:not(.file-preview button):hover {
   }
 }
 
+.highlighted {
+  background-color: #FEF3C7;
+  animation: highlight-fade 2s forwards;
+}
+
+@keyframes highlight-fade {
+  from { background-color: #FEF3C7; }
+  to { background-color: transparent; }
+}
+
+
 .loading {
   width: 100px;
   height: 100px;

--- a/src/notifications.js
+++ b/src/notifications.js
@@ -162,6 +162,8 @@ export function initNotificationEvents() {
     const notifEl = e.target.closest(".notification");
     if (notifEl) {
       const forumId = notifEl.getAttribute("data-parentforumid");
+      const targetId = notifEl.getAttribute("data-targetid");
+      const notifType = notifEl.getAttribute("data-notiftype") || "";
       if (forumId) {
         try {
           const body = document.querySelector("body");
@@ -171,7 +173,8 @@ export function initNotificationEvents() {
         } catch {
           console.error("Failed to hide notifications modal");
         }
-        openPostModalById(forumId);
+        const highlight = /Comment|Reply/.test(notifType) ? targetId : null;
+        openPostModalById(forumId, "", highlight);
       }
     }
 

--- a/src/ui/notification.html
+++ b/src/ui/notification.html
@@ -168,7 +168,7 @@
             </div>
     
             <script id="notificationTemplate" type="text/x-jsrender">
-              <div class="notification {{if Is_Read}}read{{else}}unread{{/if}} cursor-pointer flex items-start gap-3 rounded-lg p-3 hover:bg-gray-100" data-announcement="{{:ID}}"  data-parentForumid="{{:Parent_Forum_If_Not_A_Post || Parent_Forum_ID}}" @click="modalForPostOpen=true">
+              <div class="notification {{if Is_Read}}read{{else}}unread{{/if}} cursor-pointer flex items-start gap-3 rounded-lg p-3 hover:bg-gray-100" data-announcement="{{:ID}}"  data-parentForumid="{{:Parent_Forum_If_Not_A_Post || Parent_Forum_ID}}" data-targetid="{{:Parent_Forum_ID}}" data-notiftype="{{:Notification_Type}}" @click="modalForPostOpen=true">
                 <i class="fa-solid fa-file-alt mt-1 text-lg text-indigo-500"></i>
                 <div class="flex-1">
                   <div class="p3 text-[var(--color-black)]">{{:Title}}</div>


### PR DESCRIPTION
## Summary
- allow notification click to highlight the referenced comment or reply
- support highlight on modal load
- add CSS for comment highlighting

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find module 'globals')*

------
https://chatgpt.com/codex/tasks/task_b_685d32d2744c8321a55c87d8e4355b06