### PR TITLE
Add feature post admin toggle

### DIFF
--- a/src/features/posts/actions.js
+++ b/src/features/posts/actions.js
@@ -22,6 +22,7 @@ import { ensureCurrentUser } from "./user.js";
 import { processContent } from "./content.js";
 import { sendNotificationsAfterPost } from "./notifications.js";
 import { getModalTree, rerenderModal } from "./postModal.js";
+import { isFeaturePostEnabled } from "../../utils/featureToggle.js";
 
 function getImageOrientation(file) {
   return new Promise((resolve) => {
@@ -124,9 +125,11 @@ export async function createForumToSubmit(
 
   if (forumType === "Post") {
     payload.forum_tag = GLOBAL_PAGE_TAG;
+    payload.featured_forum = isFeaturePostEnabled();
   } else {
     payload.parent_forum_id = parentForumId || null;
     payload.forum_tag = GLOBAL_PAGE_TAG;
+    payload.featured_forum = false;
   }
 
   editor.find("span.mention").each(function () {

--- a/src/utils/featureToggle.js
+++ b/src/utils/featureToggle.js
@@ -1,0 +1,5 @@
+export function isFeaturePostEnabled() {
+  if (typeof document === 'undefined') return false;
+  const el = document.getElementById('featurePostToggler');
+  return !!(el && el.checked);
+}

--- a/test/featureToggle.test.js
+++ b/test/featureToggle.test.js
@@ -1,0 +1,17 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { isFeaturePostEnabled } from '../src/utils/featureToggle.js';
+
+test('isFeaturePostEnabled reflects checkbox state', () => {
+  global.document = { getElementById: () => ({ checked: true }) };
+  assert.strictEqual(isFeaturePostEnabled(), true);
+
+  global.document = { getElementById: () => ({ checked: false }) };
+  assert.strictEqual(isFeaturePostEnabled(), false);
+
+  global.document = { getElementById: () => null };
+  assert.strictEqual(isFeaturePostEnabled(), false);
+
+  delete global.document;
+});


### PR DESCRIPTION
## Summary
- add reusable helper to read admin feature checkbox
- allow createForumToSubmit to set `featured_forum` based on the new toggle
- test checkbox helper

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find module 'globals')*


------
https://chatgpt.com/codex/tasks/task_b_685d3b51df948321ba196ea67170c7f3