### PR TITLE
Fix modal comment form re-opening after updates

### DIFF
--- a/src/features/posts/postModal.js
+++ b/src/features/posts/postModal.js
@@ -178,14 +178,16 @@ export function openPostModalById(postId, author = "", highlight = null) {
   closeModalSocket();
   modalSocket = new WebSocket(WS_ENDPOINT, PROTOCOL);
 
-    modalSocket.addEventListener("open", () => {
-      modalSocket.send(JSON.stringify({ type: "CONNECTION_INIT" }));
-      keepAliveTimer = setInterval(() => {
-        modalSocket.send(JSON.stringify({ type: "KEEP_ALIVE" }));
-      }, KEEPALIVE_MS);
-    });
+  let firstUpdate = true;
 
-    modalSocket.addEventListener("message", ({ data }) => {
+  modalSocket.addEventListener("open", () => {
+    modalSocket.send(JSON.stringify({ type: "CONNECTION_INIT" }));
+    keepAliveTimer = setInterval(() => {
+      modalSocket.send(JSON.stringify({ type: "KEEP_ALIVE" }));
+    }, KEEPALIVE_MS);
+  });
+
+  modalSocket.addEventListener("message", ({ data }) => {
       let msg;
       try {
         msg = JSON.parse(data);
@@ -225,7 +227,8 @@ export function openPostModalById(postId, author = "", highlight = null) {
           expandPathToId(modalTree, highlightId);
         }
         if (container) {
-          renderModal(true);
+          renderModal(firstUpdate);
+          firstUpdate = false;
         }
       } else if (msg.type === "GQL_ERROR") {
         console.error("Subscription error", msg.payload);


### PR DESCRIPTION
## Summary
- ensure the post modal only auto-opens the comment form once

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find module 'globals')*

------
https://chatgpt.com/codex/tasks/task_b_686267e000e88321b70e01a7052c5094