### PR TITLE
Fix modal scroll reset on socket updates

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -65,6 +65,7 @@ export const state = {
   initialPostsLoaded: false,
   isConnecting: false,
   ignoreNextSocketUpdate: false,
+  ignoreNextModalUpdate: false,
   userRole: "subscriber"
 };
 export const notificationStore = {

--- a/src/features/posts/actions.js
+++ b/src/features/posts/actions.js
@@ -215,6 +215,7 @@ export async function createForumToSubmit(
           modalTree.push(newNode);
         }
         rerenderModal();
+        state.ignoreNextModalUpdate = true;
       } else {
         const parent = findNode(state.postsStore, uidParam);
         if (parent) {

--- a/src/features/posts/moderation.js
+++ b/src/features/posts/moderation.js
@@ -78,6 +78,7 @@ export function initModerationHandlers() {
         state.ignoreNextSocketUpdate = true;
         if (inModal) {
           rerenderModal();
+          state.ignoreNextModalUpdate = true;
         }
       })
       .catch((err) => {
@@ -109,7 +110,10 @@ export function initModerationHandlers() {
       const rawItem = findRawById(state.rawItems, node.id);
       if (rawItem) rawItem.featured_forum = true;
       applyFilterAndRender();
-      if (inModal) rerenderModal();
+      if (inModal) {
+        rerenderModal();
+        state.ignoreNextModalUpdate = true;
+      }
       showToast("Marked as featured");
     } catch (err) {
       console.error("Failed to mark featured", err);
@@ -137,7 +141,10 @@ export function initModerationHandlers() {
       const rawItem = findRawById(state.rawItems, node.id);
       if (rawItem) rawItem.featured_forum = false;
       applyFilterAndRender();
-      if (inModal) rerenderModal();
+      if (inModal) {
+        rerenderModal();
+        state.ignoreNextModalUpdate = true;
+      }
       showToast("Removed featured mark");
     } catch (err) {
       console.error("Failed to unmark featured", err);
@@ -171,7 +178,10 @@ export function initModerationHandlers() {
       if (nodeMain) updateTree(nodeMain, true);
       if (nodeModal && nodeModal !== nodeMain) updateTree(nodeModal, true);
       applyFilterAndRender();
-      if (inModal) rerenderModal();
+      if (inModal) {
+        rerenderModal();
+        state.ignoreNextModalUpdate = true;
+      }
       showToast("Comments disabled");
     } catch (err) {
       console.error("Failed to disable comments", err);
@@ -205,7 +215,10 @@ export function initModerationHandlers() {
       if (nodeMain) updateTree(nodeMain, false);
       if (nodeModal && nodeModal !== nodeMain) updateTree(nodeModal, false);
       applyFilterAndRender();
-      if (inModal) rerenderModal();
+      if (inModal) {
+        rerenderModal();
+        state.ignoreNextModalUpdate = true;
+      }
       showToast("Comments enabled");
     } catch (err) {
       console.error("Failed to enable comments", err);

--- a/src/features/posts/postModal.js
+++ b/src/features/posts/postModal.js
@@ -214,6 +214,10 @@ export function openPostModalById(postId, author = "", highlight = null) {
         msg.id === POST_MODAL_SUB_ID &&
         msg.payload?.data
       ) {
+        if (state.ignoreNextModalUpdate) {
+          state.ignoreNextModalUpdate = false;
+          return;
+        }
         const data = msg.payload.data.subscribeToForumPost;
         if (!data) {
           console.log("Post not found or deleted");

--- a/src/features/posts/reactions.js
+++ b/src/features/posts/reactions.js
@@ -73,6 +73,7 @@ export function initReactionHandlers() {
     $item.find(".btn-like span").text(node.upvotes);
     $item.find(".btn-like").toggleClass("liked", node.hasUpvoted);
     if (toastMsg) showToast(toastMsg);
+    if (inModal) state.ignoreNextModalUpdate = true;
   });
   $(document).off("click.btnBookmark");
   $(document).on("click.btnBookmark", ".btn-bookmark", async function (e) {
@@ -130,5 +131,6 @@ export function initReactionHandlers() {
     const $item = $(`[data-uid="${uid}"]`);
     $item.find(".btn-bookmark").toggleClass("bookmarked", node.hasBookmarked);
     if (toastMsg) showToast(toastMsg);
+    if (inModal) state.ignoreNextModalUpdate = true;
   });
 }


### PR DESCRIPTION
## Summary
- add `ignoreNextModalUpdate` flag to config
- keep post modal scroll position by ignoring socket updates after local changes
- apply new flag when creating, deleting, or reacting inside the modal

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find module 'globals')*

------
https://chatgpt.com/codex/tasks/task_b_686272cff5988321a06774c82807ac74