### PR TITLE
Add notifications page and flexible init

### DIFF
--- a/public/notifications.html
+++ b/public/notifications.html
@@ -1,0 +1,217 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Document</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="styles/style.css">
+    <script type="module" src="../src/initAlpine.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/jsrender/jsrender.min.js"></script>
+
+
+
+</head>
+<body class="max-w-[700px] max-[700px]:!w-full bg-[#f1f1f1] flex flex-col items-center min-[702px]:justify-center m-auto p-6 max-[768px]:p-0">
+
+
+
+    <!-- <div class="relative"> -->
+  
+        <div x-data="{
+          hasUnread: false,
+          init() {
+            this.checkUnread();
+            this.$watch('hasUnread', value => {
+            });
+    
+            setInterval(() => {
+              this.checkUnread();
+            }, 1000);
+          },
+          checkUnread() {
+            const container = document.getElementById('notificationContainerSocket');
+            this.hasUnread = container && container.querySelector('.unread') !== null;
+          }
+        }" x-show="hasUnread" x-cloak class="absolute top-0 right-0 -mt-1 -mr-1">
+            <span class="relative flex size-2">
+                <span class="absolute inline-flex h-full w-full animate-ping rounded-full bg-red-400 opacity-75"></span>
+                <span class="relative inline-flex size-2 rounded-full bg-red-500"></span>
+            </span>
+        </div>
+    
+        <!-- Notification Panel -->
+        <div x-init="$nextTick(() => {
+                    const initFn = () => {
+                        const container = document.getElementById('notificationContainerSocket');
+                        const hasUnread = container && container.querySelector('.unread') !== null;
+                        document.querySelector('#noNotification')?.classList.toggle('hidden', hasUnread);
+                    };
+                    setInterval(initFn, 1000);
+                })"
+            class="absolute right-0 mt-2 min-w-[300px] bg-white rounded-lg shadow-lg z-[50000] p-4 max-[702px]:fixed max-[702px]:w-full">
+    
+    
+            <div class="absolute notificationsLoader hidden inset-0 bg-[#00000095] z-10 items-center justify-center flex">
+                <div class="h-8 w-8 animate-spin rounded-full border-2 border-solid border-white border-t-transparent">
+                </div>
+            </div>
+            <div class="flex items-center justify-between mb-3">
+                <div class="flex gap-x-4 items-center">
+                    <div class="block min-[703px]:hidden" @click="showNotifications = false">
+                        <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+                            <path
+                                d="M19.707 18.292C19.7999 18.3849 19.8736 18.4952 19.9238 18.6166C19.9741 18.738 20 18.8681 20 18.9995C20 19.1309 19.9741 19.261 19.9238 19.3824C19.8736 19.5038 19.7999 19.6141 19.707 19.707C19.6141 19.7999 19.5038 19.8736 19.3824 19.9238C19.261 19.9741 19.1309 20 18.9995 20C18.8681 20 18.738 19.9741 18.6166 19.9238C18.4952 19.8736 18.3849 19.7999 18.292 19.707L10 11.4137L1.70796 19.707C1.52033 19.8946 1.26585 20 1.0005 20C0.735151 20 0.48067 19.8946 0.29304 19.707C0.105409 19.5193 5.23067e-09 19.2648 0 18.9995C-5.23067e-09 18.7341 0.10541 18.4797 0.29304 18.292L8.58633 10L0.29304 1.70796C0.105409 1.52033 -1.97701e-09 1.26585 0 1.0005C1.97701e-09 0.735151 0.105409 0.48067 0.29304 0.29304C0.48067 0.105409 0.735151 1.97701e-09 1.0005 0C1.26585 -1.97701e-09 1.52033 0.105409 1.70796 0.29304L10 8.58633L18.292 0.29304C18.4797 0.10541 18.7341 -5.23067e-09 18.9995 0C19.2648 5.23067e-09 19.5193 0.105409 19.707 0.29304C19.8946 0.48067 20 0.735151 20 1.0005C20 1.26585 19.8946 1.52033 19.707 1.70796L11.4137 10L19.707 18.292Z"
+                                fill="black" />
+                        </svg>
+                    </div>
+                    <h3 class="h3">Notifications</h3>
+    
+    
+                </div>
+                <div class="flex items-center gap-3 text-gray-500">
+                    <button @click="openSettings=true;showNotifications=false" x-tooltip="'Settings'"
+                        class="hover:text-[var(--color-primary)]">
+                        <i class="fa-solid fa-gear text-[var(--color-black)]"></i>
+                    </button>
+                    <!-- <button @click="showNotifications = false" x-tooltip="'Close'" class="hover:text-red-500">
+                    <i class="fa-solid fa-xmark"></i>
+                  </button> -->
+                </div>
+            </div>
+    
+            <div class="flex items-center justify-between mb-3 flex-row-reverse ">
+                <button id="markAllNotificationAsRead" x-tooltip="'Mark all as read'"
+                    class="text-[var(--color-black)] p3 font-medium">
+                    <!-- <i class="fa-solid fa-envelope-open"></i> -->
+                    Mark all as read
+                </button>
+                <!-- <div x-data="{ toggle: false }" x-init="$watch('toggle', value => {
+                    const hideEls = document.querySelectorAll('.read');
+                    const unreadEls = document.querySelectorAll('.unread');
+                    const noNotif = document.getElementById('noNotification');
+                    const mainNotificationContainer = document.getElementById('notificationContainerSocket');
+    
+                    hideEls.forEach(el => el.classList.toggle('hidden', value));
+    
+                    if (value && unreadEls.length === 0 && noNotif) {
+                      noNotif.classList.remove('hidden');
+                      mainNotificationContainer.classList.add('hidden');
+                    } else if (noNotif) {
+                      mainNotificationContainer.classList.remove('hidden');
+                      noNotif.classList.add('hidden');
+                    }
+                })"> -->
+                <!-- <label class="flex items-center gap-2 text-sm text-gray-600 cursor-pointer">
+                    <div class="relative h-4 w-8 rounded-full transition duration-200 ease-linear"
+                      :class="toggle ? 'bg-[var(--color-primary)]' : 'bg-gray-400'">
+                      <div
+                        class="absolute left-0 h-4 w-4 transform rounded-full border-2 bg-white transition duration-100 ease-linear"
+                        :class="toggle ? 'translate-x-full border-[var(--color-primary)]' : 'translate-x-0 border-gray-400'">
+                      </div>
+                      <input type="checkbox" class="absolute h-full w-full opacity-0 cursor-pointer"
+                        @click="toggle = !toggle" />
+                    </div>
+                    Show unread only
+                  </label> -->
+                <!--               
+                                              <div class="flex items-center gap-x-2">
+                                              
+                                                <button class="py-1 px-2 rounded text-[var(--dark-color)]">All</button>
+                                                <button class="py-1 px-2 rounded text-[var(--dark-color)]"> Unread</button>
+                                              </div>
+                                
+                                            </div> -->
+    
+                <div x-data="{ selected: 'all' }" x-init="$watch('selected', value => {
+                                                          const hideEls = document.querySelectorAll('.read');
+                                                          const unreadEls = document.querySelectorAll('.unread');
+                                                          const noNotif = document.getElementById('noNotification');
+                                                          const mainNotificationContainer = document.getElementById('notificationContainerSocket');
+                                                      
+                                                          hideEls.forEach(el => el.classList.toggle('hidden', value === 'unread'));
+                                                      
+                                                          if (value === 'unread' && unreadEls.length === 0 && noNotif) {
+                                                            noNotif.classList.remove('hidden');
+                                                            mainNotificationContainer.classList.add('hidden');
+                                                          } else if (noNotif) {
+                                                            mainNotificationContainer.classList.remove('hidden');
+                                                            noNotif.classList.add('hidden');
+                                                          }
+                                                      })">
+    
+                    <div class="flex items-center gap-x-2 text-[var(--color-black)] p3 font-medium">
+                        <button :class="selected === 'all' 
+                                                              ? 'py-1 px-2 rounded text-[var(--color-primary)] bg-[var(--color-primary-shade)]' 
+                                                              : 'py-1 px-2 rounded text-[var(--dark-color)]'"
+                            @click="selected = 'all'">
+                            All
+                        </button>
+    
+                        <button :class="selected === 'unread' 
+                                                              ? 'py-1 px-2 rounded text-[var(--color-primary)] bg-[var(--color-primary-shade)]' 
+                                                              : 'py-1 px-2 rounded text-[var(--dark-color)]'"
+                            @click="selected = 'unread'">
+                            Unread
+                        </button>
+                    </div>
+                </div>
+    
+            </div>
+            <div>
+                <div id="notificationContainerSocket"
+                    class="flex flex-col gap-2 max-h-[350px] min-h-[100px] h-auto overflow-y-auto"></div>
+                <div class="text-gray-500 text-sm p-4 hidden" id="noNotification">
+                    No notifications
+                </div>
+            </div>
+    
+            <script id="notificationTemplate" type="text/x-jsrender">
+              <div class="notification {{if Is_Read}}read{{else}}unread{{/if}} cursor-pointer flex items-start gap-3 rounded-lg p-3 hover:bg-gray-100" data-announcement="{{:ID}}"  data-parentForumid="{{:Parent_Forum_If_Not_A_Post || Parent_Forum_ID}}" data-targetid="{{:Parent_Forum_ID}}" data-notiftype="{{:Notification_Type}}" @click="modalForPostOpen=true">
+                <i class="fa-solid fa-file-alt mt-1 text-lg text-indigo-500"></i>
+                <div class="flex-1">
+                  <div class="p3 text-[var(--color-black)]">{{:Title}}</div>
+                  <div class="text-sm line-clamp-1 font-medium text-gray-900">{{:Parent_Forum?.copy}}</div>
+                  <div class="p3 text-[var(--color-grey)]">{{:~formatDate(Parent_Forum?.published_date)}}</div>
+                </div>
+              </div>
+            </script>
+    
+            <div class="mt-2 flex justify-center">
+                <button x-tooltip="'View all'" class="text-[var(--color-primary)] hover:text-blue-800 p3">
+                    View All
+                    <i class="fa-solid fa-arrow-right pl-2"></i>
+                </button>
+            </div>
+        </div>
+    
+        <!-- Settings Panel -->
+        <div id="notification-Settings" x-show="openSettings" x-transition
+            class="absolute right-0 mt-2 w-96 bg-white rounded-lg shadow-lg z-50 p-4">
+            <div class="flex items-center justify-between mb-4">
+                <h3 class="font-semibold text-lg">Notification Preferences</h3>
+                <button @click="openSettings=false" x-tooltip="'Close'" class="hover:text-red-500 text-gray-500">
+                    <i class="fa-solid fa-xmark"></i>
+                </button>
+            </div>
+    
+            <div class="space-y-3 text-sm text-gray-800">
+                <div class="space-y-3 text-sm text-gray-800" id="notificationOptionsContainer">
+                </div>
+                <div class="pt-4 text-right" id="updatePreferenceButton">
+                    <button onclick="updateNotificationPreferences()"
+                        class="px-4 py-2 bg-[var(--color-primary)] text-white rounded hover:opacity-90 transition">
+                        Save Preferences
+                    </button>
+                </div>
+            </div>
+        </div>
+    <!-- </div> -->
+
+<script type="module" src="../src/main.js"></script>
+
+
+    
+</body>
+</html>

--- a/src/main.js
+++ b/src/main.js
@@ -57,7 +57,14 @@ function startApp(tagName, contactId, displayName) {
     state.userRole = role.toLowerCase();
   }
 
-  tribute.attach(document.getElementById("post-editor"));
+  const postEditor = document.getElementById("post-editor");
+  const hasForumRoot = document.getElementById("forum-root");
+  const hasNotifContainer = document.getElementById("notificationContainerSocket");
+  const hasNotifOptions = document.getElementById("notificationOptionsContainer");
+
+  if (postEditor) {
+    tribute.attach(postEditor);
+  }
   fetchGraphQL(FETCH_CONTACTS_QUERY)
     .then((res) => {
       const contacts = res.data.calcContacts;
@@ -79,13 +86,17 @@ function startApp(tagName, contactId, displayName) {
     .catch((err) => {
       console.error("Failed to fetch contacts", err);
     });
-  getNotificationPreferences(contactId);
-  initPosts();
-  initFilePond();
-  initEmojiHandlers();
-  initGifPicker();
-  initRichText();
-  setupCreatePostModal();
+  if (hasNotifContainer || hasNotifOptions) {
+    getNotificationPreferences(contactId);
+  }
+  if (hasForumRoot) {
+    initPosts();
+    initFilePond();
+    initEmojiHandlers();
+    initGifPicker();
+    initRichText();
+    setupCreatePostModal();
+  }
 
   fetchGraphQL(GET_CONTACTS_BY_TAGS, {
     id: GLOBAL_AUTHOR_ID,
@@ -95,9 +106,13 @@ function startApp(tagName, contactId, displayName) {
       const result = res?.data?.calcContacts;
       if (Array.isArray(result) && result.length > 0) {
         setContactIncludedInTag(true);
-        connect();
-        connectNotification();
-      } else {
+        if (hasForumRoot) {
+          connect();
+        }
+        if (hasNotifContainer) {
+          connectNotification();
+        }
+      } else if (hasForumRoot) {
         const el = document.getElementById("forum-root");
         document.getElementById("skeleton-loader")?.remove();
         el.replaceChildren(
@@ -132,7 +147,9 @@ initNotificationEvents();
 initScheduledPostHandler();
 
 window.addEventListener("DOMContentLoaded", () => {
-  loadModalContacts();
+  if (document.getElementById("subscriberContacts") || document.getElementById("adminContacts")) {
+    loadModalContacts();
+  }
   //  Remove OP watermark
   setTimeout(() => {
     const el = document.querySelector('body > div:nth-child(1)');


### PR DESCRIPTION
## Summary
- add a standalone `notifications.html` for listing all notifications
- update `main.js` to only initialize posts/notifications when containers exist
- load modal contacts only when contact containers are present

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6863c17351f88321b88c53f15361d287