### PR TITLE
Link dropdown to notifications page

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -191,10 +191,10 @@
                                     </script>
   
             <div class="mt-2 flex justify-center">
-              <button x-tooltip="'View all'" class="text-[var(--color-primary)] hover:text-blue-800 p3">
+              <a href="notifications.html" x-tooltip="'View all'" class="text-[var(--color-primary)] hover:text-blue-800 p3">
                 View All
                 <i class="fa-solid fa-arrow-right pl-2"></i>
-              </button>
+              </a>
             </div>
           </div>
   

--- a/public/notifications.html
+++ b/public/notifications.html
@@ -35,7 +35,11 @@
     </div>
   </script>
 
-  <script type="module" src="../src/main.js"></script>
+  <script type="module">
+    import { setGlobals, GLOBAL_PAGE_TAG, GLOBAL_AUTHOR_DISPLAY_NAME } from '../src/config.js';
+    setGlobals(40, GLOBAL_PAGE_TAG, GLOBAL_AUTHOR_DISPLAY_NAME);
+  </script>
+  <script type="module" src="../src/notifications-only.js"></script>
 </body>
 
 </html>

--- a/src/ui/notification.html
+++ b/src/ui/notification.html
@@ -179,10 +179,10 @@
             </script>
     
             <div class="mt-2 flex justify-center">
-                <button x-tooltip="'View all'" class="text-[var(--color-primary)] hover:text-blue-800 p3">
+                <a href="notifications.html" x-tooltip="'View all'" class="text-[var(--color-primary)] hover:text-blue-800 p3">
                     View All
                     <i class="fa-solid fa-arrow-right pl-2"></i>
-                </button>
+                </a>
             </div>
         </div>
     


### PR DESCRIPTION
## Summary
- convert dropdown 'View All' button to link to notifications page
- add View All link to template version
- load notifications for user id 40 by default

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find module 'globals')*

------
https://chatgpt.com/codex/tasks/task_b_6863c5d646c88321864f22cefd6ae33e