### PR TITLE
Fix jsrender helper error in notifications

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -184,8 +184,8 @@
                                         <i class="fa-solid fa-file-alt mt-1 text-lg text-indigo-500"></i>
                                         <div class="flex-1">
                                           <div class="p3 text-[var(--color-black)]">{{:Title}}</div>
-                                          <div class="text-sm line-clamp-1 font-medium text-gray-900">{{:Parent_Forum?.copy}}</div>
-                                          <div class="p3 text-[var(--color-grey)]">{{:~formatDate(Parent_Forum?.published_date)}}</div>
+                                          <div class="text-sm line-clamp-1 font-medium text-gray-900">{{:Parent_Forum && Parent_Forum.copy}}</div>
+                                          <div class="p3 text-[var(--color-grey)]">{{:~formatDate(Parent_Forum && Parent_Forum.published_date)}}</div>
                                         </div>
                                       </div>
                                     </script>

--- a/public/notifications.html
+++ b/public/notifications.html
@@ -632,7 +632,7 @@
                                             <i class="fa-solid fa-file-alt mt-1 text-lg text-indigo-500"></i>
                                             <div class="flex-1">
                                               <div class="p3 text-[var(--color-black)]">{{:Title}}</div>
-                                              <div class="p3 text-[var(--color-grey)]">{{:~formatDate(Parent_Forum?.published_date)}}</div>
+                                              <div class="p3 text-[var(--color-grey)]">{{:~formatDate(Parent_Forum && Parent_Forum.published_date)}}</div>
                                             </div>
                                           </div>
                                         </script>
@@ -737,7 +737,7 @@
       <i class="fa-solid fa-file-alt mt-1 text-lg text-indigo-500"></i>
       <div class="flex-1">
         <div class="p3 text-[var(--color-black)]">{{:Title}}</div>
-        <div class="p3 text-[var(--color-grey)]">{{:~formatDate(Parent_Forum?.published_date)}}</div>
+        <div class="p3 text-[var(--color-grey)]">{{:~formatDate(Parent_Forum && Parent_Forum.published_date)}}</div>
       </div>
     </div>
   </script>

--- a/src/ui/notification.html
+++ b/src/ui/notification.html
@@ -172,8 +172,8 @@
                 <i class="fa-solid fa-file-alt mt-1 text-lg text-indigo-500"></i>
                 <div class="flex-1">
                   <div class="p3 text-[var(--color-black)]">{{:Title}}</div>
-                  <div class="text-sm line-clamp-1 font-medium text-gray-900">{{:Parent_Forum?.copy}}</div>
-                  <div class="p3 text-[var(--color-grey)]">{{:~formatDate(Parent_Forum?.published_date)}}</div>
+                  <div class="text-sm line-clamp-1 font-medium text-gray-900">{{:Parent_Forum && Parent_Forum.copy}}</div>
+                  <div class="p3 text-[var(--color-grey)]">{{:~formatDate(Parent_Forum && Parent_Forum.published_date)}}</div>
                 </div>
               </div>
             </script>


### PR DESCRIPTION
## Summary
- avoid optional chaining in `notificationTemplate` since JsRender doesn't parse it
- tweak all notification templates to check `Parent_Forum` with logical `&&`

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find module 'globals')*

------
https://chatgpt.com/codex/tasks/task_b_6863cd9241ac8321b08ba949d8ec97a8