### PR TITLE
Add independent notification controls

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -134,10 +134,10 @@
               </button>
   
               <div x-data="{ selected: 'all' }" x-init="$watch('selected', value => {
-                                                                                      const hideEls = document.querySelectorAll('.read');
-                                                                                      const unreadEls = document.querySelectorAll('.unread');
-                                                                                      const noNotif = document.getElementById('noNotification');
-                                                                                      const mainNotificationContainer = document.getElementById('notificationContainerSocket');
+      const mainNotificationContainer = document.getElementById('notificationContainerSocket');
+      const hideEls = mainNotificationContainer.querySelectorAll('.read');
+      const unreadEls = mainNotificationContainer.querySelectorAll('.unread');
+      const noNotif = document.getElementById('noNotification');
                                                                                   
                                                                                       hideEls.forEach(el => el.classList.toggle('hidden', value === 'unread'));
                                                                                   

--- a/public/notifications.html
+++ b/public/notifications.html
@@ -582,10 +582,10 @@
             </button>
 
             <div x-data="{ selected: 'all' }" x-init="$watch('selected', value => {
-                                                                                          const hideEls = document.querySelectorAll('.read');
-                                                                                          const unreadEls = document.querySelectorAll('.unread');
-                                                                                          const noNotif = document.getElementById('noNotification');
-                                                                                          const mainNotificationContainer = document.getElementById('notificationContainerSocket');
+          const mainNotificationContainer = document.getElementById('notificationContainerSocket');
+          const hideEls = mainNotificationContainer.querySelectorAll('.read');
+          const unreadEls = mainNotificationContainer.querySelectorAll('.unread');
+          const noNotif = document.getElementById('noNotification');
                                                                                       
                                                                                           hideEls.forEach(el => el.classList.toggle('hidden', value === 'unread'));
                                                                                       
@@ -727,6 +727,33 @@
         </div>
       </div>
 
+  </div>
+  </div>
+
+  <div class="flex items-center justify-between mb-3 flex-row-reverse">
+    <button id="markAllNotificationAsReadPage" x-tooltip="'Mark all as read'" class="text-[var(--color-black)] p3 font-medium">
+      Mark all as read
+    </button>
+    <div x-data="{ selected: 'all' }" x-init="$watch('selected', value => {
+      const pageContainer = document.getElementById('notificationContainerPage');
+      const hideEls = pageContainer.querySelectorAll('.read');
+      const unreadEls = pageContainer.querySelectorAll('.unread');
+      const noNotif = document.getElementById('noNotificationPage');
+
+      hideEls.forEach(el => el.classList.toggle('hidden', value === 'unread'));
+
+      if (value === 'unread' && unreadEls.length === 0 && noNotif) {
+        noNotif.classList.remove('hidden');
+        pageContainer.classList.add('hidden');
+      } else if (noNotif) {
+        pageContainer.classList.remove('hidden');
+        noNotif.classList.add('hidden');
+      }
+    })">
+      <div class="flex items-center gap-x-2 text-[var(--color-black)] p3 font-medium">
+        <button :class="selected === 'all' ? 'py-1 px-2 rounded text-[var(--color-primary)] bg-[var(--color-primary-shade)]' : 'py-1 px-2 rounded text-[var(--dark-color)]'" @click="selected = 'all'">All</button>
+        <button :class="selected === 'unread' ? 'py-1 px-2 rounded text-[var(--color-primary)] bg-[var(--color-primary-shade)]' : 'py-1 px-2 rounded text-[var(--dark-color)]'" @click="selected = 'unread'">Unread</button>
+      </div>
     </div>
   </div>
 

--- a/src/notifications.js
+++ b/src/notifications.js
@@ -186,15 +186,25 @@ export function initNotificationEvents() {
       }
     }
 
-    const markAll = e.target.id === "markAllNotificationAsRead";
+    const markAllTop = e.target.id === "markAllNotificationAsRead";
+    const markAllPage = e.target.id === "markAllNotificationAsReadPage";
+    const markAll = markAllTop || markAllPage;
+
+    let targetContainers = [];
+    if (markAllTop) {
+      const c = document.getElementById("notificationContainerSocket");
+      if (c) targetContainers.push(c);
+    } else if (markAllPage) {
+      const c = document.getElementById("notificationContainerPage");
+      if (c) targetContainers.push(c);
+    }
 
     let ids = [];
 
     if (markAll) {
       console.log("Marking all notifications as read");
-      const containers = getNotificationContainers();
       const elements = [];
-      containers.forEach((c) => {
+      targetContainers.forEach((c) => {
         elements.push(...c.querySelectorAll("[data-announcement].unread"));
       });
       ids = elements.map((el) => el.getAttribute("data-announcement"));
@@ -225,14 +235,13 @@ export function initNotificationEvents() {
     `;
 
     try {
-      if (markAll) {
+      if (markAllTop) {
         $(".notificationsLoader").removeClass("hidden").addClass("flex");
       }
       await fetchGraphQL(UPDATE_ANNOUNCEMENT, variables, UPDATE_ANNOUNCEMENT);
 
       if (markAll) {
-        const containers = getNotificationContainers();
-        containers.forEach((c) => {
+        targetContainers.forEach((c) => {
           c.querySelectorAll("[data-announcement].unread").forEach((el) => {
             el.classList.remove("unread");
             el.classList.add("read");
@@ -249,7 +258,7 @@ export function initNotificationEvents() {
     } catch (error) {
       console.error("Error marking announcement(s) as read:", error);
     } finally {
-      if (markAll) {
+      if (markAllTop) {
         $(".notificationsLoader").removeClass("flex").addClass("hidden");
       }
     }

--- a/src/ui/notification.html
+++ b/src/ui/notification.html
@@ -125,10 +125,10 @@
                                             </div> -->
     
                 <div x-data="{ selected: 'all' }" x-init="$watch('selected', value => {
-                                                          const hideEls = document.querySelectorAll('.read');
-                                                          const unreadEls = document.querySelectorAll('.unread');
-                                                          const noNotif = document.getElementById('noNotification');
                                                           const mainNotificationContainer = document.getElementById('notificationContainerSocket');
+                                                          const hideEls = mainNotificationContainer.querySelectorAll('.read');
+                                                          const unreadEls = mainNotificationContainer.querySelectorAll('.unread');
+                                                          const noNotif = document.getElementById('noNotification');
                                                       
                                                           hideEls.forEach(el => el.classList.toggle('hidden', value === 'unread'));
                                                       
@@ -159,6 +159,46 @@
                 </div>
     
             </div>
+
+            <div class="flex items-center justify-between mb-3 flex-row-reverse">
+                <button id="markAllNotificationAsReadPage" x-tooltip="'Mark all as read'"
+                    class="text-[var(--color-black)] p3 font-medium">
+                    Mark all as read
+                </button>
+                <div x-data="{ selected: 'all' }" x-init="$watch('selected', value => {
+                                                          const pageContainer = document.getElementById('notificationContainerPage');
+                                                          const hideEls = pageContainer.querySelectorAll('.read');
+                                                          const unreadEls = pageContainer.querySelectorAll('.unread');
+                                                          const noNotif = document.getElementById('noNotificationPage');
+
+                                                          hideEls.forEach(el => el.classList.toggle('hidden', value === 'unread'));
+
+                                                          if (value === 'unread' && unreadEls.length === 0 && noNotif) {
+                                                            noNotif.classList.remove('hidden');
+                                                            pageContainer.classList.add('hidden');
+                                                          } else if (noNotif) {
+                                                            pageContainer.classList.remove('hidden');
+                                                            noNotif.classList.add('hidden');
+                                                          }
+                                                      })">
+                    <div class="flex items-center gap-x-2 text-[var(--color-black)] p3 font-medium">
+                        <button :class="selected === 'all'
+                                                              ? 'py-1 px-2 rounded text-[var(--color-primary)] bg-[var(--color-primary-shade)]'
+                                                              : 'py-1 px-2 rounded text-[var(--dark-color)]'"
+                            @click="selected = 'all'">
+                            All
+                        </button>
+
+                        <button :class="selected === 'unread'
+                                                              ? 'py-1 px-2 rounded text-[var(--color-primary)] bg-[var(--color-primary-shade)]'
+                                                              : 'py-1 px-2 rounded text-[var(--dark-color)]'"
+                            @click="selected = 'unread'">
+                            Unread
+                        </button>
+                    </div>
+                </div>
+            </div>
+
             <div>
                 <div id="notificationContainerPage"
                     class="flex flex-col gap-2 max-h-[350px] min-h-[100px] h-auto overflow-y-auto"></div>


### PR DESCRIPTION
## Summary
- make All/Unread filter operate only inside the dropdown panel
- add buttons for filtering and marking notifications read on the main page list
- scope filtering logic in the reusable notification template
- update notification JS to handle "mark all" separately for dropdown vs page

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find module 'globals')*

------
https://chatgpt.com/codex/tasks/task_b_6864bf72de088321ae3a4b4a645141d1