### PR TITLE
Fix notifications profile and line updates

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -39,6 +39,7 @@ export let GLOBAL_AUTHOR_DISPLAY_NAME = "Eduflow Pro";
 export let GLOBAL_PAGE_TAG ="Demo_Forum";
 export function setGlobals(authorId, pageTag, displayName) {
   GLOBAL_AUTHOR_ID = Number(authorId);
+  GLOBAL_PAGE_TAG = pageTag;
   GLOBAL_AUTHOR_DISPLAY_NAME = displayName;
 }
 export const DEFAULT_AVATAR =


### PR DESCRIPTION
## Summary
- update `setGlobals` to set `GLOBAL_PAGE_TAG`
- fetch the current user profile on the notifications page
- add updateLines functionality to notifications page

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find module 'globals')*

------
https://chatgpt.com/codex/tasks/task_b_6864caacb13c8321a20119180b1c61fe