### PR TITLE
Fix delete modal on notifications page

### DIFF
--- a/public/notifications.html
+++ b/public/notifications.html
@@ -774,6 +774,21 @@
   <div id="notificationContainerPage" class="flex flex-col gap-2"></div>
   <div class="text-gray-500 text-sm p-4 hidden" id="noNotificationPage">No notifications</div>
 
+  <!-- Delete confirmation modal -->
+  <div id="delete-modal" class="hidden fixed inset-0 bg-black/50 flex items-center justify-center z-[9999999999]">
+    <div class="bg-white p-4 rounded shadow-lg w-[90%] max-w-sm">
+      <h2 id="delete-modal-title" class="text-lg mb-4"></h2>
+      <div class="flex justify-end gap-2">
+        <button id="delete-confirm" class="!bg-[var(--grey-100)] hover:!bg-[var(--color-primary)] text-white px-4 py-1 rounded">
+          Delete
+        </button>
+        <button id="delete-cancel" class="bg-gray-300 px-4 py-1 rounded">
+          Cancel
+        </button>
+      </div>
+    </div>
+  </div>
+
   <script id="notificationTemplate" type="text/x-jsrender">
     <div class="notification {{if Is_Read}}read{{else}}unread{{/if}} cursor-pointer flex items-start gap-3 rounded-lg p-3 hover:bg-gray-100" data-announcement="{{:ID}}" data-parentForumid="{{:Parent_Forum_If_Not_A_Post || Parent_Forum_ID}}" data-targetid="{{:Parent_Forum_ID}}" data-notiftype="{{:Notification_Type}}" @click="modalForPostOpen=true">
       <i class="fa-solid fa-file-alt mt-1 text-lg text-indigo-500"></i>

--- a/src/notifications-only.js
+++ b/src/notifications-only.js
@@ -17,6 +17,7 @@ import { initCommentHandlers } from "./features/posts/comments.js";
 import { initReactionHandlers } from "./features/posts/reactions.js";
 import { initPostModalHandlers } from "./features/posts/postModal.js";
 import { initPreviewHandlers } from "./features/posts/preview.js";
+import { initModerationHandlers } from "./features/posts/moderation.js";
 import { updateCurrentUserUI } from "./ui/user.js";
 import { initEmojiHandlers } from "./ui/emoji.js";
 import { initGifPicker } from "./ui/gif.js";
@@ -90,6 +91,7 @@ function initNotificationsOnly(contactId) {
   initGifPicker();
   initCommentHandlers();
   initReactionHandlers();
+  initModerationHandlers();
   initPostModalHandlers();
   initPreviewHandlers();
   refreshNotificationSubscription();


### PR DESCRIPTION
## Summary
- include post moderation handlers in notifications-only JS
- add the delete confirmation modal markup to notifications page

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find module 'globals')*

------
https://chatgpt.com/codex/tasks/task_b_6864e083df8483219bd6eee2e7588cba