### PR TITLE
Combine contact IDs for modal

### DIFF
--- a/src/api/queries.js
+++ b/src/api/queries.js
@@ -1,8 +1,4 @@
-import {
-  subscriberContactsForModal,
-  adminContactsForModal,
-  GLOBAL_AUTHOR_ID,
-} from "../config.js";
+import { userContactIds, GLOBAL_AUTHOR_ID } from "../config.js";
 import { GLOBAL_PAGE_TAG } from "../config.js";
 import { notificationStore } from "../config.js";
 
@@ -238,25 +234,11 @@ query calcContacts($id: EduflowproContactID, $name: TextScalar) {
 }
 `;
 
-export const GET_SUBSCRIBER_CONTACTS_FOR_MODAL = `
+export const GET_CONTACTS_FOR_MODAL = `
 query calcContacts {
   calcContacts(
     query: [
-      { whereIn: { id: [${subscriberContactsForModal}], _OPERATOR_: in } }
-    ]
-  ) {
-    Display_Name: field(arg: ["display_name"])
-    Profile_Image: field(arg: ["profile_image"])
-    TagName: field(arg: ["TagsData", "Tag", "name"])
-    Contact_ID: field(arg: ["id"])
-  }
-}`;
-
-export const GET_ADMIN_CONTACTS_FOR_MODAL = `
-query calcContacts {
-  calcContacts(
-    query: [
-      { whereIn: { id: [${adminContactsForModal}], _OPERATOR_: in } }
+      { whereIn: { id: [${userContactIds}], _OPERATOR_: in } }
     ]
   ) {
     Display_Name: field(arg: ["display_name"])

--- a/src/config.js
+++ b/src/config.js
@@ -77,5 +77,5 @@ export const notificationStore = {
 export const searchInput = document.getElementById("searchPost");
 export const clearIcon = document.querySelector(".clearIcon");
 export const searchIcon = document.querySelector(".searchIcon");
-export const subscriberContactsForModal = [40, 62, 86];
-export const adminContactsForModal = [83];
+// Combined list of contact IDs used when selecting a user from the modal.
+export const userContactIds = [40, 62, 83, 86];

--- a/src/domEvents.js
+++ b/src/domEvents.js
@@ -1,13 +1,10 @@
 import { DEFAULT_AVATAR } from "./config.js";
-import {
-  GET_SUBSCRIBER_CONTACTS_FOR_MODAL,
-  GET_ADMIN_CONTACTS_FOR_MODAL,
-  UPDATE_SCHEDULED_TO_POST
-} from "./api/queries.js";
+import { GET_CONTACTS_FOR_MODAL, UPDATE_SCHEDULED_TO_POST } from "./api/queries.js";
 import { fetchGraphQL } from "./api/fetch.js";
 import { showToast } from "./ui/toast.js";
 import { disableBodyScroll, enableBodyScroll } from "./utils/bodyScroll.js";
 import { setPendingFile, setFileTypeCheck } from "./features/uploads/handlers.js";
+import { GLOBAL_PAGE_TAG } from "./config.js";
 
 function renderContacts(list, containerId) {
   const container = document.getElementById(containerId);
@@ -50,18 +47,18 @@ function renderContacts(list, containerId) {
 
 export async function loadModalContacts() {
   try {
-    const [subRes, adminRes] = await Promise.all([
-      fetchGraphQL(GET_SUBSCRIBER_CONTACTS_FOR_MODAL),
-      fetchGraphQL(GET_ADMIN_CONTACTS_FOR_MODAL)
-    ]);
-
-    const subscriberContacts = subRes?.data?.calcContacts || [];
-    const adminContacts = adminRes?.data?.calcContacts || [];
+    const res = await fetchGraphQL(GET_CONTACTS_FOR_MODAL);
+    const allContacts = res?.data?.calcContacts || [];
+    const subscriberContacts = allContacts.filter(
+      (c) => c.TagName === `${GLOBAL_PAGE_TAG}_Subscriber`
+    );
+    const adminContacts = allContacts.filter(
+      (c) => c.TagName === `${GLOBAL_PAGE_TAG}_Admin`
+    );
 
     renderContacts(subscriberContacts, "subscriberContacts");
     renderContacts(adminContacts, "adminContacts");
 
-    const allContacts = [...subscriberContacts, ...adminContacts];
     if (allContacts.length === 1) {
       const c = allContacts[0];
       window.loadSelectedUserForum(


### PR DESCRIPTION
## Summary
- consolidate admin and subscriber contact IDs into a single `userContactIds` list
- use the new constant in GraphQL query `GET_CONTACTS_FOR_MODAL`
- load contacts for the modal via one query and filter by tag

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find module 'globals')*

------
https://chatgpt.com/codex/tasks/task_b_6866205f611083218daffed2a0f1244b