### PR TITLE
Fix repeated media reloads on filter change

### DIFF
--- a/src/features/posts/filters.js
+++ b/src/features/posts/filters.js
@@ -70,16 +70,13 @@ export function applyFilterAndRender() {
       `
     );
   } else {
-    // Preserve existing media elements to avoid reloads
+    // Preserve existing media elements (including images) to avoid reloads
     const frames = {};
     $container.find('.item').each(function () {
       const uid = $(this).data('uid');
-      // const f = $(this).find('iframe, video.js-player, audio.js-player');
-      // if (f.length) {
-      //   frames[uid] = f.toArray().map((el) => $(el).detach()[0]);
       const els = [];
       $(this)
-        .find('iframe, video.js-player, audio.js-player')
+        .find('iframe, video.js-player, audio.js-player, img')
         .each(function () {
           const wrapper = this.closest('.plyr');
           if (wrapper) {
@@ -102,7 +99,7 @@ export function applyFilterAndRender() {
         // newFrames.each(function (idx) {
         const newFrames = [];
         $item
-          .find('iframe, video.js-player, audio.js-player')
+          .find('iframe, video.js-player, audio.js-player, img')
           .each(function () {
             const wrapper = this.closest('.plyr');
             newFrames.push(wrapper || this);
@@ -120,40 +117,43 @@ export function applyFilterAndRender() {
 }
 
 export function initFilterHandlers() {
-$(document).on("click", ".filter-btn", function () {
-  state.currentFilter = $(this).data("filter");
-  $(".filter-btn").removeClass("active");
-  $(this).addClass("active");
-  applyFilterAndRender();
-});
+  $(document).off("click.filterBtn");
+  $(document).on("click.filterBtn", ".filter-btn", function () {
+    state.currentFilter = $(this).data("filter");
+    $(".filter-btn").removeClass("active");
+    $(this).addClass("active");
+    applyFilterAndRender();
+  });
 
   // menu toggling handled by Alpine via :class bindings
 
-// pick a file type
-$(document).on("click", "#file-filter-menu li", function () {
-  const type = $(this).data("type");
-  state.currentFileFilter = type;
+  // pick a file type
+  $(document).off("click.fileFilter");
+  $(document).on("click.fileFilter", "#file-filter-menu li", function () {
+    const type = $(this).data("type");
+    state.currentFileFilter = type;
 
-  // update button label & active menu item
-  $("#file-filter-menu li").removeClass("active");
-  $(this).addClass("active");
+    // update button label & active menu item
+    $("#file-filter-menu li").removeClass("active");
+    $(this).addClass("active");
 
-  // close dropdown and re-render
-  applyFilterAndRender();
-});
+    // close dropdown and re-render
+    applyFilterAndRender();
+  });
 
-// pick a sort type
-$(document).on("click", "#sort-filter-menu li", function () {
-  const sort = $(this).data("sort");
-  state.currentSort = sort;
+  // pick a sort type
+  $(document).off("click.sortFilter");
+  $(document).on("click.sortFilter", "#sort-filter-menu li", function () {
+    const sort = $(this).data("sort");
+    state.currentSort = sort;
 
-  // update button label & active menu item
-  $("#sort-filter-menu li").removeClass("active");
-  $(this).addClass("active");
+    // update button label & active menu item
+    $("#sort-filter-menu li").removeClass("active");
+    $(this).addClass("active");
 
-  // close dropdown and re-render
-  applyFilterAndRender();
-});
+    // close dropdown and re-render
+    applyFilterAndRender();
+  });
 
 
 


### PR DESCRIPTION
## Summary
- avoid reloading images and players when filtering posts
- prevent duplicate filter event handlers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6870a80b89788321bf40ec0158918e34