### PR TITLE
Fix GIF search input focus

### DIFF
--- a/src/ui/gif.js
+++ b/src/ui/gif.js
@@ -114,6 +114,9 @@ export function initGifPicker() {
 
     $('#gif-modal').removeClass('hidden');
     $('#gif-search-input').val('');
+    // Focus the search field so typing immediately works and
+    // prevents the editor from keeping focus when the picker opens
+    $('#gif-search-input').trigger('focus');
     search();
   });
 


### PR DESCRIPTION
## Summary
- keep focus on GIF search field when picker opens

## Testing
- `npm run lint` *(fails: Cannot find module 'globals')*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6875e1a92ab08321b93bbabf3174092b