### PR TITLE
Fix gif search focus

### DIFF
--- a/src/ui/gif.js
+++ b/src/ui/gif.js
@@ -115,8 +115,11 @@ export function initGifPicker() {
     $('#gif-modal').removeClass('hidden');
     $('#gif-search-input').val('');
     // Focus the search field so typing immediately works and
-    // prevents the editor from keeping focus when the picker opens
-    $('#gif-search-input').trigger('focus');
+    // prevents the editor from keeping focus when the picker opens.
+    // Using a timeout ensures other click handlers don't steal focus.
+    setTimeout(() => {
+      $('#gif-search-input').trigger('focus');
+    }, 0);
     search();
   });
 


### PR DESCRIPTION
## Summary
- ensure focus stays on gif search box by delaying focus call

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6875fda310a48321b6eb06cad66de87d