### PR TITLE
Fix GIF picker focus

### DIFF
--- a/src/ui/gif.js
+++ b/src/ui/gif.js
@@ -91,6 +91,9 @@ export function initGifPicker() {
   // Handle toggle click: choose input inside create-post-modal or fallback to comment-form
   $(document).on('click', '.gif-toggle', function (e) {
     e.stopPropagation();
+    // Prevent other delegated click handlers (like the rich text toolbar
+    // handler) from refocusing the editor after the modal opens
+    e.stopImmediatePropagation();
     const $toggle = $(this);
     console.log('GIF toggle clicked:', $toggle);
     let actualInput;


### PR DESCRIPTION
## Summary
- avoid toolbar click handler stealing focus from GIF picker

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find module 'globals')*

------
https://chatgpt.com/codex/tasks/task_b_6876072f9fa88321aac2edaa3325b86e