### PR TITLE
Fix GIF search field focus

### DIFF
--- a/src/ui/gif.js
+++ b/src/ui/gif.js
@@ -97,11 +97,15 @@ export function initGifPicker() {
     const $toggle = $(this);
     console.log('GIF toggle clicked:', $toggle);
     let actualInput;
-    if (document.querySelector('#create-post-modal')?.classList.contains('show')) {
-      const wrapper = document.querySelector('#create-post-modal');
-      actualInput = wrapper.querySelector('#file-input');
+    const createPostModal = document.querySelector('#create-post-modal');
+    const inCreatePost = createPostModal?.classList.contains('show');
+    if (inCreatePost) {
+      actualInput = createPostModal.querySelector('#file-input');
+      // Move the GIF modal inside the focus-trapped modal so its input can gain focus
+      $('#gif-modal').appendTo(createPostModal);
     } else {
       actualInput = document.querySelector('.comment-form').querySelector('#file-input');
+      $('#gif-modal').appendTo('body');
     }
     if (!actualInput) {
       console.error('Couldn’t find the correct file input');


### PR DESCRIPTION
## Summary
- move GIF modal into create-post modal when opened from there so focus trap allows searching

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find module 'globals')*

------
https://chatgpt.com/codex/tasks/task_b_68760e312fa483219ac090f6c89c5dec